### PR TITLE
docs: remove/fix broken links to repos and wording

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,5 +6,6 @@ The following people have contributed to this repository:
 * Siegfried Kiermayer, SAP SE, https://github.com/siegfriedk
 * Daniel Miehle, BMW Group AG, https://github.com/danielmiehle
 * Fabian Grün, Mercedes-Benz Tech Innovation GmbH, https://github.com/FaGru3n
+* Carsten Lenz, Mercedes-Benz Tech Innovation GmbH, https://github.com/carslen
 
 Please add yourself to this list, if you contribute to the content.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,7 @@ more.
 
 The project maintains the following source code repositories
 
-* https://github.com/eclipse/tractusx
-* https://github.com/eclipse-tractusx/community
+* https://github.com/eclipse-tractusx/sig-release
 
 ## Eclipse Development Process
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -28,8 +28,7 @@ SPDX-License-Identifier: Apache-2.0
 
 The project maintains the following source code repositories:
 
-* https://github.com/eclipse/tractusx
-* https://github.com/eclipse-tractusx/community
+* https://github.com/eclipse-tractusx/sig-release
 
 ## Cryptography
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ is used to align the overarching Tractus-X releases.
 
 In case you experienced a bug, unexpected behaviour, or you want to propose enhancements to Eclipse Tractus-X,
 feel free to use on of the provided [issue templates](https://github.com/eclipse-tractusx/sig-project-management/issues/new/choose) and describe your request.
-Please be aware, that not every feature request can be integrated and that we also cannot treat every issue with highest priority.
+Please be aware, that not every feature request can be integrated and that we also cannot treat every issue with the highest priority.
 
 Every Release planning will be kicked off by two public alignment sessions. The dates and further details will be shared via
 [tractusx-dev](https://accounts.eclipse.org/mailing-list/tractusx-dev) mailing list.


### PR DESCRIPTION
Remove broken link to GH org eclipse-tractusx and fixed link to sig-release (community → sig-release) in `CONTRIBUTING.md` and `NOTICE.md`. Small changes to wording in README.md.
