### PR TITLE
fix: only use oauth for GitHub client, if token set

### DIFF
--- a/trg-checks-dashboard/internal/templating/tractusx.go
+++ b/trg-checks-dashboard/internal/templating/tractusx.go
@@ -182,10 +182,10 @@ func getMetadataForRepo(repo tractusx.Repository) *tractusx.Metadata {
 func init() {
 	if os.Getenv("GITHUB_ACCESS_TOKEN") == "" {
 		gitHubClient = github.NewClient(nil)
+	} else {
+		httpClient := oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: os.Getenv("GITHUB_ACCESS_TOKEN")},
+		))
+		gitHubClient = github.NewClient(httpClient)
 	}
-
-	httpClient := oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: os.Getenv("GITHUB_ACCESS_TOKEN")},
-	))
-	gitHubClient = github.NewClient(httpClient)
 }


### PR DESCRIPTION
## Description

The GitHub client initialization always used an httpClient with OAuth authentication.
OAuth authentication can only be used if a GitHub PAT is provided. 

This change fixes hat and let's the GitHub client create it's own httpClient

fixes #38 

