### PR TITLE
chore: tractusx metadata

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -1,5 +1,6 @@
 product: "sig-release"
 leadingRepository: "https://github.com/eclipse-tractusx/sig-release"
+supportingRepository: true
 repositories:
   - name: "sig-release"
     usage: "Home of release and feature management."

--- a/.tractusx
+++ b/.tractusx
@@ -1,0 +1,6 @@
+product: "sig-release"
+leadingRepository: "https://github.com/eclipse-tractusx/sig-release"
+repositories:
+  - name: "sig-release"
+    usage: "Home of release and feature management."
+    url: "https://github.com/eclipse-tractusx/sig-release"


### PR DESCRIPTION
PR to add .tractusx metadata file with basic configuration + new flag helping identify supporting repository. The flag will be used by quality checks dashboard for better presentation of repositories.