### PR TITLE
fix: adopt .tractusx metadata to new repo categorisation

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -1,6 +1,6 @@
 product: "sig-release"
 leadingRepository: "https://github.com/eclipse-tractusx/sig-release"
-supportingRepository: true
+repoCategory: "special"
 repositories:
   - name: "sig-release"
     usage: "Home of release and feature management."


### PR DESCRIPTION
Little PR to adopt .tractusx metadata with regards to approach change having more general repository categorisation.