### PR TITLE
docs: Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ is used to align the overarching Tractus-X releases.
 ### How can I get involved
 
 In case you experienced a bug, unexpected behaviour, or you want to propose enhancements to Eclipse Tractus-X,
-feel free to use on of the provided [issue templates](https://github.com/eclipse-tractusx/sig-project-management/issues/new/choose) and describe your request.
+feel free to use one of the provided [issue templates](https://github.com/eclipse-tractusx/sig-project-management/issues/new/choose) and describe your request.
 Please be aware, that not every feature request can be integrated and that we also cannot treat every issue with the highest priority.
 
 Every Release planning will be kicked off by two public alignment sessions. The dates and further details will be shared via
@@ -55,21 +55,23 @@ Additionally an `Assignee` is selected, who will coordinate efforts to solve the
 
 After these details are clarified, an issue is moved to `Backlog` to open it for detailed timeline planning. In this status, discussions about a fitting `Iteration` is held.
 
-As soon as actual work is started in the selecte iteration, the issue is set to `Work in Progress`. This is especially helpful on our project milestone views to get an overview of the release progress.
+As soon as actual work is started in the selected iteration, the issue is set to `Work in Progress`. This is especially helpful on our project milestone views to get an overview of the release progress.
 
 The final status `Done` is set, as soon as all relevant implementations are done, tested and released. This has to be achieved for every change in every involved component.
 
 ### Planning component changes
 
-While the [Release Planning Board](https://github.com/orgs/eclipse-tractusx/projects/26) is used to coordinate overarching feature and bug request,
+While the [Release Planning Board](https://github.com/orgs/eclipse-tractusx/projects/26) is used to coordinate overarching feature and bug requests,
 we encourage every component team to break these issues down to their component repositories/projects.
 When doing so, make sure you link to the overarching issue in your component issue description.
 
 ## Release Management Acceptance Criteria
+
 The release participation can be initiated by creating issues for the acceptance criteria check from the Issue templates.
-Each release the Templates for the acceptance criteria will be renewed. There are two Paths for processing the acceptance criteria for an application team to participate in a release.
+Each release the templates for the acceptance criteria will be renewed. There are two paths for processing the acceptance criteria for an application team to participate in a release.
 
 ### The Release Happy Path for the Acceptance Criteria
+
 The three process steps to get to the status you need to pass the Q-Gate are shown in the happy path process flow.
 
 Each acceptance criteria issue in GitHub contains a note with the prime contacts so that it is clear who is the assigned expert or release manager.
@@ -77,6 +79,7 @@ Each acceptance criteria issue in GitHub contains a note with the prime contacts
 ![Happy Path](docs/static/releasemanagement-acceptance-happy-path.svg)
 
 ### The other Release Path
+
 If the evidence is not sufficient so that the criterium can not be accepted in the quality gate (QG), obligations for the product team will be defined to make a reassessment.
 ![The other Path](docs/static/releasemanagement-acceptance-other-path.svg)
 


### PR DESCRIPTION
## Description
Fix some typos in the README.md

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
