### PR TITLE
chore: update version quality checks

### DIFF
--- a/trg-checks-dashboard/DEPENDENCIES
+++ b/trg-checks-dashboard/DEPENDENCIES
@@ -16,12 +16,11 @@ go/golang/github.com%2Fcloudflare/circl/v1.3.3, BSD-3-Clause, approved, clearlyd
 go/golang/github.com%2Fcpuguy83%2Fgo-md2man/v2/v2.0.2, MIT, approved, clearlydefined
 go/golang/github.com%2Fcreack/pty/v1.1.7, MIT, approved, clearlydefined
 go/golang/github.com%2Fcreack/pty/v1.1.9, MIT, approved, clearlydefined
-go/golang/github.com%2Fcyphar/filepath-securejoin/v0.2.3, BSD-3-Clause, approved, clearlydefined
 go/golang/github.com%2Fcyphar/filepath-securejoin/v0.2.4, BSD-3-Clause, approved, clearlydefined
 go/golang/github.com%2Fdavecgh/go-spew/v1.1.0, ISC, approved, clearlydefined
 go/golang/github.com%2Fdavecgh/go-spew/v1.1.1, ISC, approved, clearlydefined
 go/golang/github.com%2Fdocopt/docopt-go/v0.0.0-20180111231733-ee0de3bc6815, MIT, approved, #5650
-go/golang/github.com%2Feclipse-tractusx/tractusx-quality-checks/v0.7.2, Apache-2.0, approved, #10682
+go/golang/github.com%2Feclipse-tractusx/tractusx-quality-checks/v0.7.3, Apache-2.0, approved, #10682
 go/golang/github.com%2Femicklei%2Fgo-restful/v3/v3.10.1, MIT, approved, clearlydefined
 go/golang/github.com%2Femirpasic/gods/v1.12.0, BSD-2-Clause AND ISC, approved, clearlydefined
 go/golang/github.com%2Fenvoyproxy/go-control-plane/v0.9.1-0.20191026205805-5f8ba28d4473, Apache-2.0, approved, #5639

--- a/trg-checks-dashboard/go.mod
+++ b/trg-checks-dashboard/go.mod
@@ -3,7 +3,7 @@ module trg-checks-dashboard
 go 1.20
 
 require (
-	github.com/eclipse-tractusx/tractusx-quality-checks v0.7.2
+	github.com/eclipse-tractusx/tractusx-quality-checks v0.7.3
 	github.com/google/go-github/v53 v53.2.0
 	github.com/otiai10/copy v1.12.0
 	github.com/spf13/cobra v1.7.0

--- a/trg-checks-dashboard/go.sum
+++ b/trg-checks-dashboard/go.sum
@@ -31,8 +31,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
-github.com/eclipse-tractusx/tractusx-quality-checks v0.7.2 h1:bB6NqHSmj9gwOAuzO9GOsJjKFcvszOEqnjClOFb3YqU=
-github.com/eclipse-tractusx/tractusx-quality-checks v0.7.2/go.mod h1:7Wp8dJddrzA+XtawtNv6+MkcnF7lsQ5E9MjgrW++/Ak=
+github.com/eclipse-tractusx/tractusx-quality-checks v0.7.3 h1:3tXv7aZdhHlEINMjJ4ZIpkdwgAzhNSspiAyIdIhK2vk=
+github.com/eclipse-tractusx/tractusx-quality-checks v0.7.3/go.mod h1:7Wp8dJddrzA+XtawtNv6+MkcnF7lsQ5E9MjgrW++/Ak=
 github.com/emicklei/go-restful/v3 v3.10.1 h1:rc42Y5YTp7Am7CS630D7JmhRjq4UlEUuEKfrDac4bSQ=
 github.com/emicklei/go-restful/v3 v3.10.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=


### PR DESCRIPTION
## Description
- update tractus-quality-check version to 0.7.3
- update DEPENDENCIES

updates https://github.com/eclipse-tractusx/sig-infra/issues/259

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
