### PR TITLE
fix: build-and-deploy-dashboard.yaml with GitHub API token

### DIFF
--- a/.github/workflows/build-and-deploy-dashboard.yaml
+++ b/.github/workflows/build-and-deploy-dashboard.yaml
@@ -25,6 +25,7 @@ on:
       github_token:
         description: "Auth token for GitHub API requests"
         required: false
+        default: ${{ github.token }}
   schedule:
     # Run every day at 01:00 at night
     - cron: "0 1 * * *" # UTC time


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
- modify default github_api_token

updates https://github.com/eclipse-tractusx/sig-infra/issues/263

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
