### PR TITLE
fix: archived repos detection

### DIFF
--- a/trg-checks-dashboard/internal/templating/tractusx.go
+++ b/trg-checks-dashboard/internal/templating/tractusx.go
@@ -48,10 +48,10 @@ func CheckProducts() ([]CheckedProduct, []Repository, []Repository) {
 	for _, repo := range repos {
 		metadata := getMetadataForRepo(repo)
 
-		if metadata == nil {
-			unhandledRepos = append(unhandledRepos, repo)
-		} else if repo.Archived {
+		if repo.Archived {
 			archivedRepos = append(archivedRepos, repo)
+		} else if  metadata == nil {
+			unhandledRepos = append(unhandledRepos, repo)
 		} else {
 			repoInfoByRepoUrl[repo.URL] = repoInfo{metadata: *metadata, repoName: repo.Name, repoUrl: repo.URL}
 		}


### PR DESCRIPTION
PR to fix the way archived repos are identified, they don't need to have .tractux metadata anymore.