### PR TITLE
fix: web errors formatting improvement

### DIFF
--- a/trg-checks-dashboard/DEPENDENCIES
+++ b/trg-checks-dashboard/DEPENDENCIES
@@ -20,7 +20,7 @@ go/golang/github.com%2Fcyphar/filepath-securejoin/v0.2.4, BSD-3-Clause, approved
 go/golang/github.com%2Fdavecgh/go-spew/v1.1.0, ISC, approved, clearlydefined
 go/golang/github.com%2Fdavecgh/go-spew/v1.1.1, ISC, approved, clearlydefined
 go/golang/github.com%2Fdocopt/docopt-go/v0.0.0-20180111231733-ee0de3bc6815, MIT, approved, #5650
-go/golang/github.com%2Feclipse-tractusx/tractusx-quality-checks/v0.8.0, , restricted, clearlydefined
+go/golang/github.com%2Feclipse-tractusx/tractusx-quality-checks/v0.8.0, Apache-2.0, approved, #11189
 go/golang/github.com%2Femicklei%2Fgo-restful/v3/v3.10.1, MIT, approved, clearlydefined
 go/golang/github.com%2Femirpasic/gods/v1.12.0, BSD-2-Clause AND ISC, approved, clearlydefined
 go/golang/github.com%2Fenvoyproxy/go-control-plane/v0.9.1-0.20191026205805-5f8ba28d4473, Apache-2.0, approved, #5639

--- a/trg-checks-dashboard/DEPENDENCIES
+++ b/trg-checks-dashboard/DEPENDENCIES
@@ -20,7 +20,7 @@ go/golang/github.com%2Fcyphar/filepath-securejoin/v0.2.4, BSD-3-Clause, approved
 go/golang/github.com%2Fdavecgh/go-spew/v1.1.0, ISC, approved, clearlydefined
 go/golang/github.com%2Fdavecgh/go-spew/v1.1.1, ISC, approved, clearlydefined
 go/golang/github.com%2Fdocopt/docopt-go/v0.0.0-20180111231733-ee0de3bc6815, MIT, approved, #5650
-go/golang/github.com%2Feclipse-tractusx/tractusx-quality-checks/v0.7.3, Apache-2.0, approved, #10682
+go/golang/github.com%2Feclipse-tractusx/tractusx-quality-checks/v0.8.0, , restricted, clearlydefined
 go/golang/github.com%2Femicklei%2Fgo-restful/v3/v3.10.1, MIT, approved, clearlydefined
 go/golang/github.com%2Femirpasic/gods/v1.12.0, BSD-2-Clause AND ISC, approved, clearlydefined
 go/golang/github.com%2Fenvoyproxy/go-control-plane/v0.9.1-0.20191026205805-5f8ba28d4473, Apache-2.0, approved, #5639

--- a/trg-checks-dashboard/go.mod
+++ b/trg-checks-dashboard/go.mod
@@ -3,7 +3,7 @@ module trg-checks-dashboard
 go 1.20
 
 require (
-	github.com/eclipse-tractusx/tractusx-quality-checks v0.7.3
+	github.com/eclipse-tractusx/tractusx-quality-checks v0.8.0
 	github.com/google/go-github/v53 v53.2.0
 	github.com/otiai10/copy v1.12.0
 	github.com/spf13/cobra v1.7.0

--- a/trg-checks-dashboard/go.sum
+++ b/trg-checks-dashboard/go.sum
@@ -31,8 +31,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
-github.com/eclipse-tractusx/tractusx-quality-checks v0.7.3 h1:3tXv7aZdhHlEINMjJ4ZIpkdwgAzhNSspiAyIdIhK2vk=
-github.com/eclipse-tractusx/tractusx-quality-checks v0.7.3/go.mod h1:7Wp8dJddrzA+XtawtNv6+MkcnF7lsQ5E9MjgrW++/Ak=
+github.com/eclipse-tractusx/tractusx-quality-checks v0.8.0 h1:7nF6Vfi8haUiAEmBo9P0RnoUHEooM3VINbb7LmxIH0Q=
+github.com/eclipse-tractusx/tractusx-quality-checks v0.8.0/go.mod h1:7Wp8dJddrzA+XtawtNv6+MkcnF7lsQ5E9MjgrW++/Ak=
 github.com/emicklei/go-restful/v3 v3.10.1 h1:rc42Y5YTp7Am7CS630D7JmhRjq4UlEUuEKfrDac4bSQ=
 github.com/emicklei/go-restful/v3 v3.10.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=

--- a/trg-checks-dashboard/internal/templating/tractusx.go
+++ b/trg-checks-dashboard/internal/templating/tractusx.go
@@ -89,15 +89,9 @@ func runQualityChecks(repo Repository) CheckedRepository {
 		guidelineCheck := GuidelineCheck{
 			Passed:           testResult.Passed,
 			Optional:         check.IsOptional(),
+			ErrorDescription: testResult.ErrorDescription,
 			GuidelineUrl:     check.ExternalDescription(),
 			GuidelineName:    check.Name(),
-			ErrorDescription: func() string {
-								if testResult.ErrorDescriptionWeb == "" {
-									return testResult.ErrorDescription
-								}
-								return testResult.ErrorDescriptionWeb
-								}(),
-
 		}
 		checkedRepo.GuidelineChecks = append(checkedRepo.GuidelineChecks, guidelineCheck)
 	}

--- a/trg-checks-dashboard/internal/templating/tractusx.go
+++ b/trg-checks-dashboard/internal/templating/tractusx.go
@@ -103,6 +103,7 @@ func runQualityChecks(repo Repository) CheckedRepository {
 
 func initializeChecksForDirectory(dir string) []tractusx.QualityGuideline {
 	var checks []tractusx.QualityGuideline
+	tractusx.ErrorOutputFormat = tractusx.WebErrOutputFormat
 
 	checks = append(checks, docs.NewReadmeExists(dir))
 	checks = append(checks, docs.NewInstallExists(dir))

--- a/trg-checks-dashboard/internal/templating/tractusx.go
+++ b/trg-checks-dashboard/internal/templating/tractusx.go
@@ -89,9 +89,15 @@ func runQualityChecks(repo Repository) CheckedRepository {
 		guidelineCheck := GuidelineCheck{
 			Passed:           testResult.Passed,
 			Optional:         check.IsOptional(),
-			ErrorDescription: testResult.ErrorDescription,
 			GuidelineUrl:     check.ExternalDescription(),
 			GuidelineName:    check.Name(),
+			ErrorDescription: func() string {
+								if testResult.ErrorDescriptionWeb == "" {
+									return testResult.ErrorDescription
+								}
+								return testResult.ErrorDescriptionWeb
+								}(),
+
 		}
 		checkedRepo.GuidelineChecks = append(checkedRepo.GuidelineChecks, guidelineCheck)
 	}

--- a/trg-checks-dashboard/web/templates/body.html.tmpl
+++ b/trg-checks-dashboard/web/templates/body.html.tmpl
@@ -73,7 +73,7 @@
                                         <td class="center">
                                             <div class="valign-wrapper">
                                                 <i class="material-icons red-text">heart_broken</i>
-                                                <a class="tooltipped" data-position="top" data-tooltip="{{ .ErrorDescription }}" href="{{ .GuidelineUrl }}" target="_blank"> {{ .GuidelineName }}</a>
+                                                <a class="tooltipped" data-position="top" data-html="true" data-tooltip="{{ .ErrorDescription }}" href="{{ .GuidelineUrl }}" target="_blank"> {{ .GuidelineName }}</a>
                                             </div>
                                         </td>
                                         {{ end }}
@@ -139,7 +139,7 @@
                                             <td class="center">
                                                 <div class="valign-wrapper">
                                                     <i class="material-icons red-text">heart_broken</i>
-                                                    <a class="tooltipped" data-position="top" data-tooltip="{{ .ErrorDescription }}" href="{{ .GuidelineUrl }}" target="_blank"> {{ .GuidelineName }}</a>
+                                                    <a class="tooltipped" data-position="top" data-html="true" data-tooltip="{{ .ErrorDescription }}" href="{{ .GuidelineUrl }}" target="_blank"> {{ .GuidelineName }}</a>
                                                 </div>
                                             </td>
                                             {{ end }}
@@ -206,7 +206,7 @@
                                             <td class="center">
                                                 <div class="valign-wrapper">
                                                     <i class="material-icons red-text">heart_broken</i>
-                                                    <a class="tooltipped" data-position="top" data-tooltip="{{ .ErrorDescription }}" href="{{ .GuidelineUrl }}" target="_blank"> {{ .GuidelineName }}</a>
+                                                    <a class="tooltipped" data-position="top" data-html="true" data-tooltip="{{ .ErrorDescription }}" href="{{ .GuidelineUrl }}" target="_blank"> {{ .GuidelineName }}</a>
                                                 </div>
                                             </td>
                                             {{ end }}


### PR DESCRIPTION
PR to improve quality check tool errors displayed as tooltips in the quality dashboard. By adding html data option within the tooltip it allows using html tags like line breaks. Implementation facilitates Web as well as CLI based formatted error messages.

Updates https://github.com/eclipse-tractusx/sig-infra/issues/265