### PR TITLE
fix: re-enable quality check web error msg

### DIFF
--- a/trg-checks-dashboard/internal/templating/tractusx.go
+++ b/trg-checks-dashboard/internal/templating/tractusx.go
@@ -136,7 +136,8 @@ func runQualityChecks(repo Repository, dir string) CheckedRepository {
 
 func initializeChecksForDirectory(dir string) []tractusx.QualityGuideline {
 	var checks []tractusx.QualityGuideline
-
+	tractusx.ErrorOutputFormat = tractusx.WebErrOutputFormat
+	
 	checks = append(checks, docs.NewReadmeExists(dir))
 	checks = append(checks, docs.NewInstallExists(dir))
 	checks = append(checks, docs.NewChangelogExists(dir))


### PR DESCRIPTION
PR to re-enable web error messages in the dashboard for quality checks. 