### PR TITLE
fix: helm chart rendering

### DIFF
--- a/release-automation/internal/dashboard/tractusx.go
+++ b/release-automation/internal/dashboard/tractusx.go
@@ -145,6 +145,7 @@ func initializeChecksForDirectory(dir string) []tractusx.QualityGuideline {
 	checks = append(checks, repo.NewLeadingRepositoryDefined(dir))
 	checks = append(checks, container.NewAllowedBaseImage(dir))
 	checks = append(checks, helm.NewHelmStructureExists(dir))
+	checks = append(checks, helm.NewResourceMgmt(dir))
 
 	return checks
 }

--- a/release-automation/internal/dashboard/tractusx.go
+++ b/release-automation/internal/dashboard/tractusx.go
@@ -145,7 +145,6 @@ func initializeChecksForDirectory(dir string) []tractusx.QualityGuideline {
 	checks = append(checks, repo.NewLeadingRepositoryDefined(dir))
 	checks = append(checks, container.NewAllowedBaseImage(dir))
 	checks = append(checks, helm.NewHelmStructureExists(dir))
-	checks = append(checks, helm.NewResourceMgmt(dir))
 
 	return checks
 }


### PR DESCRIPTION
PR fixes rendering helm charts which contain subcharts within resources mgmt check.

updates https://github.com/eclipse-tractusx/sig-infra/issues/251