### PR TITLE
chore: enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,11 @@ updates:
     open-pull-requests-limit: 3
     schedule:
       interval: "weekly"
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
+    directory: "/"
+    open-pull-requests-limit: 3
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,22 @@
+# #############################################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# #############################################################################
+
 version: 2
 updates:
   # Maintain dependencies for release-automation

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,10 @@ updates:
     open-pull-requests-limit: 3
     schedule:
       interval: "weekly"
+
+# Maintain dependencies for release-notifier
+  - package-ecosystem: "gomod"
+    directory: "/release-notifier"
+    open-pull-requests-limit: 3
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  # Maintain dependencies for release-automation
+  - package-ecosystem: "gomod"
+    directory: "/release-automation"
+    open-pull-requests-limit: 3
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
PR to enable dependabot version updates for sig-release repository. Configuration includes release-automation, release-notifier and github actions setup with limitation up to 3 PRs at once each, weekly interval.

Fixes https://github.com/eclipse-tractusx/sig-infra/issues/401