### PR TITLE
docs: remove iterations from board and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Our issues do have important properties, that enable our planning process. These
 - __Issue Type:__ To separate between bugs, feature requests and release criterias, we use a custom field `Issue Type`
 - __Milestone:__ Every Tractus-X release is represented by a `Milestone`. You can use this field to get a rough idea about the ETA
 - __Status:__ The status field is used to integrate the progress of an issue
-- __Iteration:__ `Milestone`s are divided in multiple iterations. The 'Iteration' field is used to do fine-grained timeline planning
 
 ### Issue statuses
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

- remove the description to iterations.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
