### PR TITLE
fix: enhance base image check with regards to alpine case

### DIFF
--- a/release-automation/internal/container/allowed_base_image_check.go
+++ b/release-automation/internal/container/allowed_base_image_check.go
@@ -71,8 +71,7 @@ func (a *AllowedBaseImage) Test() *tractusx.QualityResult {
 			fmt.Printf("Could not read dockerfile from Path %s\n", dockerfilePath)
 			continue
 		}
-
-		if !isAllowedBaseImage(file.baseImage()) {
+		if !isAllowedBaseImage(strings.Split(file.baseImage(), ":")[0]) {
 			checkPassed = false
 			deniedBaseImages = append(deniedBaseImages, file.baseImage())
 		}

--- a/release-automation/internal/container/allowed_base_image_check_test.go
+++ b/release-automation/internal/container/allowed_base_image_check_test.go
@@ -115,6 +115,17 @@ func TestShouldPassAlpineAsPlainBaseImage(t *testing.T) {
 	}
 }
 
+func TestShouldFailImageAlpineBased(t *testing.T) {
+	tmpDir := t.TempDir()
+	file := dockerFileWithBaseImage("postgres:15.4-alpine3.17")
+	_ = file.writeTo(tmpDir)
+
+	result := NewAllowedBaseImage(tmpDir).Test()
+	if result.Passed {
+		t.Errorf("Check should fail, not approved base image (alpine based).")
+	}
+}
+
 func TestShouldAllowBaseImagesFromWhitelist(t *testing.T) {
 	baseImageAllowList = []string{"my/baseimage", "my/other/baseimage"}
 

--- a/release-automation/internal/container/allowed_base_image_check_test.go
+++ b/release-automation/internal/container/allowed_base_image_check_test.go
@@ -104,6 +104,17 @@ func TestShouldFailIfAtLeastOneDockerfileWithUnallowedBaseImageIsFound(t *testin
 	}
 }
 
+func TestShouldPassAlpineAsPlainBaseImage(t *testing.T) {
+	tmpDir := t.TempDir()
+	file := dockerFileWithBaseImage("alpine:3.19.1")
+	_ = file.writeTo(tmpDir)
+
+	result := NewAllowedBaseImage(tmpDir).Test()
+	if !result.Passed {
+		t.Errorf("Check should pass, pure alpine base image is allowed.")
+	}
+}
+
 func TestShouldAllowBaseImagesFromWhitelist(t *testing.T) {
 	baseImageAllowList = []string{"my/baseimage", "my/other/baseimage"}
 
@@ -184,3 +195,4 @@ func saveMetadataConfigToSkip(dockerfilePath string, dir string) {
 	bytes, _ := yaml.Marshal(&metadata)
 	_ = os.WriteFile(path.Join(dir, ".tractusx"), bytes, 0644)
 }
+


### PR DESCRIPTION
Added 2 unit tests for alpine case
Enhanced base image check to pass unit tests with regards to alpine case.
 
Fixes https://github.com/eclipse-tractusx/tractusx-quality-checks/issues/52