### PR TITLE
fix: skip aligned base image check

### DIFF
--- a/release-automation/internal/container/allowed_base_image_check.go
+++ b/release-automation/internal/container/allowed_base_image_check.go
@@ -118,7 +118,7 @@ func getDockerfilePathsToIgnore(dir string) []string {
 
 func containsString(slice []string, element string) bool {
 	for _, v := range slice {
-		if v == element {
+		if strings.Contains(element, v) {
 			return true
 		}
 	}


### PR DESCRIPTION
PR to fix skip aligned base image check replacing used qual comparision by contains function. 
Reason for that is because dockerfilePath uses absolute path, however dockerfilesToSkip are relative paths (from metadata) hence if basedir was different than "." it doesn't work properly and required, configured dockerfiles are never skipped.