### PR TITLE
chore:included feedback from 24.03 release

### DIFF
--- a/.github/ISSUE_TEMPLATE/3_product_release_checks.md
+++ b/.github/ISSUE_TEMPLATE/3_product_release_checks.md
@@ -9,6 +9,7 @@ labels: compliance, documentation, "security analysis", "test results"
 
 Please provide information on what you want to be included in the Eclipse Tractus-X release.
 If you are not owner of this issue, please provide the information as comment to the issue.
+To receive review from committer or subject matter expert, assign the issue to the person.
 
 **Version to be included in Eclipse Tractus-X release**: *version placeholder*
 


### PR DESCRIPTION
The subject matter experts do check their assigned issues rather than reading the comments in which they have been mentioned. In the release 24.03 this was unclear in some cases, this caused tasks that have been delayed. 