### PR TITLE
add initial content for release consolidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ To make adopting the latest [Catena-X Standards](https://catena-x.net/de/standar
 
 ## Release Cycle - major vs. minor release
 
-Tractus-X operates on a quarterly release cycle. Each quarter, a new Tractus-X release tractus-x-release.md following [CalVer](https://calver.org) is released.
+Tractus-X operates on a quarterly release cycle. Each quarter, a new [Tractus-X release](docs/tractus-x-release.md) following [CalVer](https://calver.org) is released.
 
-Each Tractus-X release contains [multiple products](product_release.md).
+Each Tractus-X release contains [multiple products](docs/product_release.md).
 
 Once per year, Tractus-X releases a major release, making the remaining three releases minor releases. A major release may contain critical breaking changes that have a major impact on data space participants, such as changes to enablement services. A minor release contains backward compatible functionality. In addition, patch versions provide backward compatible bug and security fixes.
 

--- a/README.md
+++ b/README.md
@@ -1,94 +1,27 @@
 # SIG-Release
 
-Welcome to SIG-Release, home of release and feature management.
-If you are new to this repository, you might find the [getting started guide](docs/getting-started.md) useful.
-If you are interested in the current state of planning, have a look at our [Release Planning Board](https://github.com/orgs/eclipse-tractusx/projects/26)
+## Intro
 
-## The planning and roadmap process
+Welcome to SIG-Release, home of release and feature management. If you are new to this repository, you might find the getting started guide useful. If you are interested in the current state of planning, have a look at our Release Planning Board.
 
-We follow a coordinated approach to plan improvements of Eclipse Tractus-X. see also [Open Planning and Refinement](docs/open-refinement-and-planning.md).
+[Catena-X Standards](https://catena-x.net/de/standard-library) are the foundation for certifying any software product operating in the Catena-X data space. Those standards are the binding reference to obtain a valid certificate.
 
-While every repository in the [eclipse-tractusx](https://github.com/eclipse-tractusx) GitHub organization
-has its own issue management, the [Release Planning Board](https://github.com/orgs/eclipse-tractusx/projects/26)
-is used to align the overarching Tractus-X releases.
+To make adopting the latest [Catena-X Standards](https://catena-x.net/de/standard-library) easier, reference implementations are provided through the Eclipse Tractus-X Project
 
-### How can I get involved
+## Release Cycle - major vs. minor release
 
-In case you experienced a bug, unexpected behaviour, or you want to propose enhancements to Eclipse Tractus-X,
-feel free to use one of the provided [issue templates](https://github.com/eclipse-tractusx/sig-release/issues/new/choose) and describe your request.
-Please be aware, that not every feature request can be integrated and that we also cannot treat every issue with the highest priority.
+Tractus-X operates on a quarterly release cycle. Each quarter, a new Tractus-X release tractus-x-release.md following [CalVer](https://calver.org) is released.
 
-Every Release planning will be kicked off by two public alignment sessions. The dates and further details will be shared via
-[tractusx-dev](https://accounts.eclipse.org/mailing-list/tractusx-dev) mailing list.
-In addition to that, you can also find public meetings and info about how to join on our
-[Open Meetings](https://eclipse-tractusx.github.io/community/open-meetings) community page. 
-Issues or bug reports, that should be discussed in these meetings, have to be opened prior to the meeting via
-our [issue templates](https://github.com/eclipse-tractusx/sig-release/issues/new/choose).
+Each Tractus-X release contains [multiple products](product_release.md).
 
-### What can I expect
+Once per year, Tractus-X releases a major release, making the remaining three releases minor releases. A major release may contain critical breaking changes that have a major impact on data space participants, such as changes to enablement services. A minor release contains backward compatible functionality. In addition, patch versions provide backward compatible bug and security fixes.
 
-We really welcome every contribution. Every Bug report and feature proposal takes time to prepare,
-is valuable to our project, and we very much appreciate this input.
-We are giving our best to give a first feedback in one week.
-If we should miss that, please stick with us and just use the commenting function to remind us of the issue.
+Please check the Change Log(s) for content, known knowns, and backward compatibility since the [calendar versioning scheme](https://calver.org) shows the year and month of release.
 
-### Issue structure
+See [planning](./docs/planning.md), for information about planning and roadmap process.
+See [product release](./docs/product_release.md), for information about singular product releases.
+See [Tractus-X release](./docs/tractus-x-release.md), for our overarching release strategy.
 
-Our issues do have important properties, that enable our planning process. These are:
-
-- __Labels:__ We use them to indicate the involved teams (kit or foss component). A label for each involved component is added to an issue
-- __Issue Type:__ To separate between bugs, feature requests and release criterias, we use a custom field `Issue Type`
-- __Milestone:__ Every Tractus-X release is represented by a `Milestone`. You can use this field to get a rough idea about the ETA
-- __Status:__ The status field is used to integrate the progress of an issue
-
-### Issue statuses
-
-The following statuses are defined:
-
-- __Inbox:__ This is the initial status of all issues. It indicates, that involved components have to be identified and additional information gathered
-- __Backlog:__ If enough information is gathered, and we agreed to work on the issue, it is set from `Inbox` to `Backlog` to indicate it is ready for timeline planning
-- __Work in Progress:__ The issue is actively been worked on.
-- __Done:__ All relevant parts have been implemented and released
-
-### Issue process
-
-Every new feature proposal or bug report will be handled as issue in status `Inbox` initially. The alignment meetings are used to discuss the purpose and impact of the current issues.
-While in `Inbox` status, the involved components are discovered and respective `Labels` are added. If already possible, a desired `Milestone` can be set.
-Additionally, an `Assignee` is selected, who will coordinate efforts to solve the issue.
-
-After these details are clarified, an issue is moved to `Backlog` to open it for detailed timeline planning. In this status, discussions about a fitting `Iteration` is held.
-
-As soon as actual work is started in the selected iteration, the issue is set to `Work in Progress`. This is especially helpful on our project milestone views to get an overview of the release progress.
-
-The final status `Done` is set, as soon as all relevant implementations are done, tested and released. This has to be achieved for every change in every involved component.
-
-### Planning component changes
-
-While the [Release Planning Board](https://github.com/orgs/eclipse-tractusx/projects/26) is used to coordinate overarching feature and bug requests,
-we encourage every component team to break these issues down to their component repositories/projects.
-When doing so, make sure you link to the overarching issue in your component issue description.
-
-## Release Management Acceptance Criteria
-
-The release participation can be initiated by creating issues for the acceptance criteria check from the Issue templates.
-Each release the templates for the acceptance criteria will be renewed. There are two paths for processing the acceptance criteria for an application team to participate in a release.
-
-### Guidance on how to use the issue Templates
-
-Select issue type "release_ac" to make the issue visible in the [Release Management Kanban Board](https://github.com/orgs/eclipse-tractusx/projects/26/views/17). Futhermore select the appropriate milestone to distingush the ticket from other releases.
-
-### The Release Happy Path for the Acceptance Criteria
-
-The three process steps to get to the status you need to pass the Q-Gate are shown in the happy path process flow.
-
-Each acceptance criteria issue in GitHub contains a note with the prime contacts so that it is clear who is the assigned expert or release manager.
-
-![Happy Path](docs/static/releasemanagement-acceptance-happy-path.svg)
-
-### The other Release Path
-
-If the evidence is not sufficient so that the criterium can not be accepted in the quality gate (QG), obligations for the product team will be defined to make a reassessment.
-![The other Path](docs/static/releasemanagement-acceptance-other-path.svg)
 
 
 ## Contact

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Each Tractus-X release contains [multiple products](docs/product_release.md).
 
 Once per year, Tractus-X releases a major release, making the remaining three releases minor releases. A major release may contain critical breaking changes that have a major impact on data space participants, such as changes to enablement services. A minor release contains backward compatible functionality. In addition, patch versions provide backward compatible bug and security fixes.
 
-Please check the Change Log(s) for content, known knowns, and backward compatibility since the [calendar versioning scheme](https://calver.org) shows the year and month of release.
+Please check the [Change Log(s)](CHANGELOG.md) for content, known knowns, and backward compatibility since the [calendar versioning scheme](https://calver.org) shows the year and month of release.
 
 See [planning](./docs/planning.md), for information about planning and roadmap process.
 See [product release](./docs/product_release.md), for information about singular product releases.

--- a/docs/open-refinement-and-planning.md
+++ b/docs/open-refinement-and-planning.md
@@ -1,3 +1,5 @@
+# Open Refinement and Planning
+
 Welcome to our guide on the open refinement and planning processes for our open source community.
 Effective planning and transparent communication are critical for the success of our project.
 Here, we'll outline how our community can participate and leverage these processes to ensure smooth and efficient collaboration.

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -1,0 +1,66 @@
+# Roadmap and Release Process
+
+We follow a coordinated approach to plan improvements of Eclipse Tractus-X. See also [Open Planning and Refinement](open-refinement-and-planning.md).
+
+While every repository in the [eclipse-tractusx](https://github.com/eclipse-tractusx) GitHub organization has its own issue management, the [Release Planning Board](https://github.com/orgs/eclipse-tractusx/projects/26) is used to align the overarching Tractus-X releases.
+
+
+### How can I get involved
+
+In case you experienced a bug, unexpected behaviour, or you want to propose enhancements to Eclipse Tractus-X,
+feel free to use one of the provided [issue templates](https://github.com/eclipse-tractusx/sig-release/issues/new/choose) and describe your request.
+Please be aware, that not every feature request can be integrated and that we also cannot treat every issue with the highest priority.
+
+Every Release planning will be kicked off by two public alignment sessions. The dates and further details will be shared via [tractusx-dev](https://accounts.eclipse.org/mailing-list/tractusx-dev) mailing list.
+In addition to that, you can also find public meetings and info about how to join on our [Open Meetings](https://eclipse-tractusx.github.io/community/open-meetings) community page.
+Issues or bug reports, that should be discussed in these meetings, have to be opened prior to the meeting via our [issue templates](https://github.com/eclipse-tractusx/sig-release/issues/new/choose).
+
+
+### What can I expect
+
+We really welcome every contribution. Every Bug report and feature proposal takes time to prepare,
+is valuable to our project, and we very much appreciate this input.
+We are giving our best to give a first feedback in one week.
+If we should miss that, please stick with us and just use the commenting function to remind us of the issue.
+
+
+### Issue structure
+
+Our issues do have important properties, that enable our planning process. These are:
+- **Labels:** We use them to indicate the involved teams (kit or foss product). A label for each involved product is added to an issue
+- **Issue Type:** To separate between bugs, feature requests and release criteria, we use a custom field `Issue Type`
+- **Milestone:** Every Tractus-X release is represented by a `Milestone`.
+- **Status:** The status field is used to integrate the progress of an issue
+
+
+### Issue statuses
+
+The following statuses are defined:
+- **Inbox:** This is the initial status of all issues. It indicates, that involved products have to be identified and additional information gathered
+- **Backlog:** If enough information is gathered, and we agreed to work on the issue, it is set from `Inbox` to `Backlog` to indicate it is ready for timeline planning
+- **Work in Progress:** The issue is actively being worked on.
+- **Done:** All relevant parts have been implemented and released
+
+
+### Issue process
+
+Every new feature proposal or bug report will be handled as issue in status `Inbox` initially. The alignment meetings are used to discuss the purpose and impact of the current issues. While in `Inbox` status, the involved products are discovered and respective `Labels` are added. Additionally, an `Assignee` is selected, who will coordinate efforts to solve the issue.
+After these details are clarified, an issue is moved to `Backlog` to open it for detailed timeline planning. In this status, discussions about a fitting `Iteration` is held.
+The fully refined status "backlog" is the entry point for our "open planning" ceremony. During "open planning" a milestone is set for each feature. This represents a commitment, given by the open source community to finalize the feature in due time.
+As soon as actual work is started in the selected iteration, the issue is set to `Work in Progress`. This is especially helpful on our project milestone views to get an overview of the release progress.
+
+
+### Issue hierarchy (WIP)
+
+@stephanbcbauer to formulate details
+=> detailled features are planned and executed within the repositories of the respective product. Summary features are planned and managed on "SIG release" level...
+
+
+### Planning product changes
+
+While the [Release Planning Board](https://github.com/orgs/eclipse-tractusx/projects/26) is used to coordinate overarching feature and bug requests, we encourage every product team to break these issues down to their product repositories/projects.
+When doing so, make sure you link to the overarching issue in your product issue description.
+
+See [product release](product_release.md), for information about singular product releases.
+
+See [Tractus-X release](tractus-x-release.md), for our overarching release strategy.

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -53,7 +53,7 @@ As soon as actual work is started in the selected iteration, the issue is set to
 ### Issue hierarchy (WIP)
 
 @stephanbcbauer to formulate details
-=> detailled features are planned and executed within the repositories of the respective product. Summary features are planned and managed on "SIG release" level...
+=> detailed features are planned and executed within the repositories of the respective product. Summary features are planned and managed on "SIG release" level...
 
 
 ### Planning product changes

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -5,7 +5,7 @@ We follow a coordinated approach to plan improvements of Eclipse Tractus-X. See 
 While every repository in the [eclipse-tractusx](https://github.com/eclipse-tractusx) GitHub organization has its own issue management, the [Release Planning Board](https://github.com/orgs/eclipse-tractusx/projects/26) is used to align the overarching Tractus-X releases.
 
 
-### How can I get involved
+## How can I get involved
 
 In case you experienced a bug, unexpected behaviour, or you want to propose enhancements to Eclipse Tractus-X,
 feel free to use one of the provided [issue templates](https://github.com/eclipse-tractusx/sig-release/issues/new/choose) and describe your request.
@@ -16,7 +16,7 @@ In addition to that, you can also find public meetings and info about how to joi
 Issues or bug reports, that should be discussed in these meetings, have to be opened prior to the meeting via our [issue templates](https://github.com/eclipse-tractusx/sig-release/issues/new/choose).
 
 
-### What can I expect
+## What can I expect
 
 We really welcome every contribution. Every Bug report and feature proposal takes time to prepare,
 is valuable to our project, and we very much appreciate this input.
@@ -24,7 +24,7 @@ We are giving our best to give a first feedback in one week.
 If we should miss that, please stick with us and just use the commenting function to remind us of the issue.
 
 
-### Issue structure
+## Issue structure
 
 Our issues do have important properties, that enable our planning process. These are:
 - **Labels:** We use them to indicate the involved teams (kit or foss product). A label for each involved product is added to an issue
@@ -33,7 +33,7 @@ Our issues do have important properties, that enable our planning process. These
 - **Status:** The status field is used to integrate the progress of an issue
 
 
-### Issue statuses
+## Issue statuses
 
 The following statuses are defined:
 - **Inbox:** This is the initial status of all issues. It indicates, that involved products have to be identified and additional information gathered
@@ -42,7 +42,7 @@ The following statuses are defined:
 - **Done:** All relevant parts have been implemented and released
 
 
-### Issue process
+## Issue process
 
 Every new feature proposal or bug report will be handled as issue in status `Inbox` initially. The alignment meetings are used to discuss the purpose and impact of the current issues. While in `Inbox` status, the involved products are discovered and respective `Labels` are added. Additionally, an `Assignee` is selected, who will coordinate efforts to solve the issue.
 After these details are clarified, an issue is moved to `Backlog` to open it for detailed timeline planning. In this status, discussions about a fitting `Iteration` is held.
@@ -50,13 +50,13 @@ The fully refined status "backlog" is the entry point for our "open planning" ce
 As soon as actual work is started in the selected iteration, the issue is set to `Work in Progress`. This is especially helpful on our project milestone views to get an overview of the release progress.
 
 
-### Issue hierarchy (WIP)
+## Issue hierarchy (WIP)
 
 @stephanbcbauer to formulate details
 => detailed features are planned and executed within the repositories of the respective product. Summary features are planned and managed on "SIG release" level...
 
 
-### Planning product changes
+## Planning product changes
 
 While the [Release Planning Board](https://github.com/orgs/eclipse-tractusx/projects/26) is used to coordinate overarching feature and bug requests, we encourage every product team to break these issues down to their product repositories/projects.
 When doing so, make sure you link to the overarching issue in your product issue description.

--- a/docs/product_release.md
+++ b/docs/product_release.md
@@ -1,0 +1,59 @@
+Product releases are done by creating a GitHub release. Every release is following the [semantic versioning](https://semver.org/) pattern and must be marked in the git history via tag.
+If suitable for the product teams development process, release candidate versions can help to provide early previews of a product for integration testing.
+
+Tractus-X products do follow their own release process. They are individually developed and therefore no strict workflow is enforced. To ensure a consistent view on releases, the following aspects should still be met:
+A CHANGELOG.md file, that follows keep a changelog recommendations is maintained and updated with descriptions for the current product release. Links to GitHub external artifacts (i.e. mvncentral or Docker Hub) are referenced. GitHub releases are used to publish artifacts. Git tags are added accordingly (usually done automatically). The changelog content of the current release is documented in the GitHub release. Helm charts are released into the aligned helm chart repository.
+Please check the leading product repositories for details.
+Independent of the technical details of product release processes, the released artifacts and minimum level of quality assurance is the same across all of them.
+The release contents for individual products are planned in the [open refinement and planning](./open-refinement-and-planning.md) sessions. These sessions define the scope for all dataspace products, and therefore paint a clear picture of enhancements necessary for every single product. The product teams themselves are then responsible to define fine-grained task breakdowns as suiting their own needs.
+> **HINT:**
+> If product enhancements contribute to an overarching dataspace feature, please link the dataspace feature defined in `sig-release` in your product issue.
+> These links can be done in either the description or any comment on your issue. Use `eclipse-tractusx/sig-release#issue-number`
+Once planning activities for a certain iteration are completed, the implementation phase is starting and product teams can coordinate, where necessary through our [communication channels](https://eclipse-tractusx.github.io/docs/oss/getting-started#communication-channels).
+
+Every product needs to adhere to the [Tractus-X release guidelines (TRGs)](https://eclipse-tractusx.github.io/docs/release).
+> **HINT:**
+> this is in addition to the integration- and unit-test suites the teams maintain
+> Take special care about legal requirements defined in TRG 7. They **must** be adhered to on every PR.
+Compliance to these guidelines **should** be verified on every PR, but **must** be complied with, as soon as a new product version is planned to be included in the Tractus-X release.
+
+Integration tests are performed by maintaining a Product Umbrella Chart, that deploys all relevant dataspace products to spin up an artificial dataspace based on Tractus-X products.
+There is a dedicated repository [eclipse-tractusx/tractus-x-umbrella](https://github.com/eclipse-tractusx/tractus-x-umbrella), that is maintained collectively to reflect the latest product release versions.
+
+Products **must** opt-in to the process in order to be included in a Tractus-X release.
+This is done by requesting a release review 4 weeks prior to the planned release date, using the "Product Release Check" [issue template](https://github.com/eclipse-tractusx/sig-release/issues/new/choose).
+
+
+## Artifacts
+
+- GitHub release (Changelog + Sourcecode)
+  Most Tractus-X products are software products. In these cases, packaging the sourcecode together with a list of used dependencies is a good starting point and should be included as artifact of a release in almost any case.
+
+- Container images
+  All container images provided by tractus-x are only provided for development, testing etc. without any guarantee on license or security. Feel free to use them on your own risk, all images can be build by yourself through provided Dockerfiles.
+
+- Product Umbrella Helm Chart
+  Applications developed in the Tractus-X context typically provide a Helm chart for easy deployment on kubernetes.
+  To add a Helm chart as a release artifact it has to be packaged. There are multiple tools, that help packaging charts. We recommend using the chart-releaser-action GitHub action though, since together with activated GitHub pages, it can transform your repository to function as Helm chart repository on its own.
+
+Additionally, Tractus-X offers a central Helm chart repository. It supports two channels for released Helm charts - dev and stable.
+The dev-channel is used to publish the most recently released charts. It is updated nightly and automatically pulls in the latest chart releases of the eclipse-tractusx GitHub organization.
+The stable channel is used by the release management group, to publish all helm charts, that were successfully tested and included in an overarching release. This means, that the stable channel only includes specific versions of product charts, that are tested to the best of our knowledge to work together with other stable charts.
+
+Patching strategy
+tbd
+
+Helm Repository
+For information about using the Tractus-X Helm repository, please refer to the charts repository.
+
+
+## Versioning
+
+- Semantic Versioning
+
+
+## Quality Assurance
+
+- Defined in TRGs
+- Responsibility of every contributor
+- Currently still verified in a Quality Gate process. TBD if this process will continue.

--- a/docs/product_release.md
+++ b/docs/product_release.md
@@ -1,10 +1,18 @@
-Product releases are done by creating a GitHub release. Every release is following the [semantic versioning](https://semver.org/) pattern and must be marked in the git history via tag.
+Product releases are done by creating a GitHub release. Every release is following the [Semantic Versioning](https://semver.org/) pattern and must be marked in the git history via tag.
 If suitable for the product teams development process, release candidate versions can help to provide early previews of a product for integration testing.
 
 Tractus-X products do follow their own release process. They are individually developed and therefore no strict workflow is enforced. To ensure a consistent view on releases, the following aspects should still be met:
-A CHANGELOG.md file, that follows keep a changelog recommendations is maintained and updated with descriptions for the current product release. Links to GitHub external artifacts (i.e. mvncentral or Docker Hub) are referenced. GitHub releases are used to publish artifacts. Git tags are added accordingly (usually done automatically). The changelog content of the current release is documented in the GitHub release. Helm charts are released into the aligned helm chart repository.
+- A CHANGELOG.md file, that follows keep a changelog recommendations is maintained and updated with descriptions for the current product release
+- Links to GitHub external artifacts (i.e. mvncentral or Docker Hub) are referenced
+- GitHub releases are used to publish artifacts
+- Git tags are added accordingly (usually done automatically)
+- The changelog content of the current release is documented in the GitHub release
+- Helm charts are released into the aligned helm chart repository
+
 Please check the leading product repositories for details.
+
 Independent of the technical details of product release processes, the released artifacts and minimum level of quality assurance is the same across all of them.
+
 The release contents for individual products are planned in the [open refinement and planning](./open-refinement-and-planning.md) sessions. These sessions define the scope for all dataspace products, and therefore paint a clear picture of enhancements necessary for every single product. The product teams themselves are then responsible to define fine-grained task breakdowns as suiting their own needs.
 > **HINT:**
 > If product enhancements contribute to an overarching dataspace feature, please link the dataspace feature defined in `sig-release` in your product issue.
@@ -27,18 +35,23 @@ This is done by requesting a release review 4 weeks prior to the planned release
 ## Artifacts
 
 - GitHub release (Changelog + Sourcecode)
+
   Most Tractus-X products are software products. In these cases, packaging the sourcecode together with a list of used dependencies is a good starting point and should be included as artifact of a release in almost any case.
 
 - Container images
-  All container images provided by tractus-x are only provided for development, testing etc. without any guarantee on license or security. Feel free to use them on your own risk, all images can be build by yourself through provided Dockerfiles.
+
+  All container images provided by Tractus-X are only provided for development, testing etc. without any guarantee on license or security. Feel free to use them on your own risk, all images can be build by yourself through provided Dockerfiles.
 
 - Product Umbrella Helm Chart
+
   Applications developed in the Tractus-X context typically provide a Helm chart for easy deployment on kubernetes.
   To add a Helm chart as a release artifact it has to be packaged. There are multiple tools, that help packaging charts. We recommend using the chart-releaser-action GitHub action though, since together with activated GitHub pages, it can transform your repository to function as Helm chart repository on its own.
 
 Additionally, Tractus-X offers a central Helm chart repository. It supports two channels for released Helm charts - dev and stable.
-The dev-channel is used to publish the most recently released charts. It is updated nightly and automatically pulls in the latest chart releases of the eclipse-tractusx GitHub organization.
-The stable channel is used by the release management group, to publish all helm charts, that were successfully tested and included in an overarching release. This means, that the stable channel only includes specific versions of product charts, that are tested to the best of our knowledge to work together with other stable charts.
+
+The **dev-channel** is used to publish the most recently released charts. It is updated nightly and automatically pulls in the latest chart releases of the [eclipse-tractusx](https://github.com/eclipse-tractusx) GitHub organization.
+
+The **stable-channel** is used by the release management group, to publish all helm charts, that were successfully tested and included in an overarching release. This means, that the stable channel only includes specific versions of product charts, that are tested to the best of our knowledge to work together with other stable charts.
 
 Patching strategy
 tbd
@@ -49,11 +62,11 @@ For information about using the Tractus-X Helm repository, please refer to the c
 
 ## Versioning
 
-- Semantic Versioning
+- [Semantic Versioning](https://semver.org/)
 
 
 ## Quality Assurance
 
-- Defined in TRGs
+- Defined in [Tractus-X Release Guidelines / TRGs](https://eclipse-tractusx.github.io/docs/release)
 - Responsibility of every contributor
 - Currently still verified in a Quality Gate process. TBD if this process will continue.

--- a/docs/product_release.md
+++ b/docs/product_release.md
@@ -1,3 +1,7 @@
+# Product Release
+
+## Intro
+
 Product releases are done by creating a GitHub release. Every release is following the [Semantic Versioning](https://semver.org/) pattern and must be marked in the git history via tag.
 If suitable for the product teams development process, release candidate versions can help to provide early previews of a product for integration testing.
 

--- a/docs/tractus-x-release.md
+++ b/docs/tractus-x-release.md
@@ -1,0 +1,128 @@
+## Intro
+
+Tractus-X operates on a quarterly release cycle. Each quarter, a new Tractus-X release following CalVer is released. Each Tractus-X release contains multiple products product_release.md.
+
+Once per year, Tractus-X releases a major release, making the remaining three releases minor releases. A major release may contain critical breaking changes that have a major impact on data space participants, such as changes to enablement services.
+
+A minor release contains backward compatible functionality. In addition, patch versions provide backward compatible bug and security fixes.
+
+The overarching Tractus-X releases are coordinated by the release management group (SIG Release). This team collaborates with the currently released versions of Tractus-X products to formulate the overarching release.
+
+As mentioned in [planning.md](planning.md) the Tractus-X project follows an overarching qualification process that all official quarterly Tractus-X releases adhere to. This process applies E2E activities for testing and security for all relevant release participants in compound, which stakeholders can build on. Each product can/shall be released on demand on a higher cadence, see [product_release.md].
+
+
+## Scope / Content
+
+The Tractus-X release process aims to ensure compatibility of Tractus-X products and defines common quality criteria.
+
+The desired enhancement of the dataspace functionality is planned in the [open refinement and planning](open-refinement-and-planning.md) sessions.
+
+Past release documentation can be found in [eclipse-tractusx/tractus-x-release](https://github.com/eclipse-tractusx/tractus-x-release).
+
+Note: In every quarterly TX release, we shall expect evolutions (new versions) of some products (see [product_release.md]). But also some other products may NOT face a change/up-revision in the given iteration. Nevertheless, those products (“carry-over”) are still essential parts of the release bundle.
+
+Products **must** opt-in to the process in order to be included in a Tractus-X release. (see product release.md)
+
+
+## Process abstract (future state; or “to-be”)
+
+- Planning
+- Feature Work and Product Release
+- Quality assurance in parallel
+- Opt-In for participation in TX Release
+- Completion of Q-Assurance
+- TX Release
+
+Once feature work on product level is initiated, the quality assurance of the foreseen release package runs in parallel. The vehicle of Umbrella helm charts is used to continuously test pre-defined product bundles. Automatically and environment-less.
+
+Reference onion rings: (add URL)
+
+Example for cxOS (https://catena-x.net/fileadmin/_online_media_/231006_Whitepaper_Tractus-X.pdf (https://catena-x.net/fileadmin/_online_media_/231006_Whitepaper_Tractus-X.pdf):
+
+A configured umbrella helm chart starts-up all relevant products. No matter if carry-over versions of a previous TX release or evolutions of the current iteration. User Journey tests (e2e) are automatically performed - customized for the respective bundle of products and within given boundary conditions.
+
+Any findings are looped back to the product development teams. Product teams are obliged to fix any defects which prevent successful testing of the bundle.
+
+A bundle is ready for Tractus-X release, once product feature work is completed for all products and e2e-testing was successful without critical findings.
+Additionally, manual e2e tests may apply. Environment and execution tbd.
+
+
+### Operational steps to conclude the TX release
+
+Pre-requisites
+!!! If the last release, approved by the Eclipse Foundation, is more than a year old, you have to initiate a new release on the Eclipse Tractus-X Project page at least a week prior to the planned release date (see the Release steps)
+•	Helm chart versions and app versions for all products intended for the release
+•	An official announcement text highlighting release features, vital for the announcement email
+•	An optional official announcement image usable for the Eclipse Tractus-X Project page
+
+1. Verify the presence of all helm chart versions in the release helm repository
+1. Verify all referenced links are working (documentation, kits, etc.)
+1. Create a Pull Request with the new changelog entry
+1.	Gather feedback and proceed with the merge
+1.	Create a GitHub release and incorporate the new changelog entry
+1.	Insert the new changelog entry under versions on the eclipse-tractusx changelog page
+1.	Register a new Tractus-X Release on the Eclipse Tractus-X Project page (Navigate to the Create new release button/link on the right side)
+1.	Modify the Download section on the Eclipse Tractus-X Project page via the Downloads, Software Repositories, and Marketplace -> Downloads Message section
+1. Compose an email to the tractusx-dev mailing list announcing the new release
+      Example:
+
+```
+Subject line: [tractusx-dev] Announcing Tractus-X 24.03 - Latest Release Now Available 🎉
+Hello Tractus-X Community,
+
+We're excited to announce the latest release of Tractus-X 24.03.
+
+🔗 Release and Helm Charts
+You can view the full changelog and Helm chart versions for each component here: Tractus-X 24.03 Release Notes.
+
+🙏 Acknowledgments
+We'd like to thank all contributors, users, and community members who have played a role in this release. Your feedback, contributions, and ongoing support fuel the advancement of this project.
+
+💬 We Value Your Feedback
+We invite you to test out the new suite release and share your experiences with us. If you encounter any issues or have suggestions for future improvements, please submit them on our GitHub repository.
+
+Thank you for your continued support and enthusiasm for the Tractus-X project. Together, we're driving the future of the ecosystem.
+
+Best regards,
+
+Björn, Daniel, Sigi and Stephan
+Eclipse Tractus-X Project Leads
+```
+
+
+## Artifacts
+
+Note: Tractus-X products are released in multiple formats. The number of artifacts and its format varies between individual product and the overarching releases.
+- Changelog (overarching features)
+- Umbrella Helm Chart(s)
+- Overarching architecture documentation (if available)
+
+Tractus-X offers a central Helm chart repository. It supports two channels for released Helm charts - dev and stable.
+The dev-channel is used to publish the most recently released charts. It is updated nightly and automatically pulls in the latest chart releases of the eclipse-tractusx GitHub organization.
+The stable channel is used by the release management group, to publish all helm charts, that were successfully tested and included in an overarching release. This means, that the stable channel only includes specific versions of product charts, that are tested to the best of our knowledge to work together with other stable charts.
+
+
+## Versioning
+
+- Calendar versioning
+
+
+### Quality Assurance
+
+- User Journey tests automatically executed via `helm test` (nightly + on every product rc PR)
+- User Journey tests (e2e) defined in e2e-testing repo
+
+
+Release Management Acceptance Criteria (TBD if this process will continue):
+The release participation can be initiated by creating issues for the acceptance criteria check from the Issue templates. Each release the templates for the acceptance criteria may be updated. There are two paths for processing the acceptance criteria for a product to participate in a TX-release.
+
+Guidance on how to use the issue Templates
+Select issue type "release_ac" to make the issue visible in the Release Management Kanban Board. Furthermore select the appropriate milestone to distinguish the ticket from other releases.
+
+The Release Happy Path for the Acceptance Criteria
+The three process steps to get to the status you need to pass the Q-Gate are shown in the happy path process flow.
+Each acceptance criteria issue in GitHub contains a note with the prime contacts so that it is clear who is the assigned expert or release manager.
+Happy Path graph
+
+The other Release Path
+If the evidence is not sufficient so that the criterium can not be accepted in the quality gate (QG), obligations for the product team will be defined to make a reassessment.

--- a/docs/tractus-x-release.md
+++ b/docs/tractus-x-release.md
@@ -1,6 +1,6 @@
 ## Intro
 
-Tractus-X operates on a quarterly release cycle. Each quarter, a new Tractus-X release following CalVer is released. Each Tractus-X release contains multiple products product_release.md.
+Tractus-X operates on a quarterly release cycle. Each quarter, a new Tractus-X release following [CalVer](https://calver.org) is released. Each Tractus-X release contains multiple [products](product_release.md).
 
 Once per year, Tractus-X releases a major release, making the remaining three releases minor releases. A major release may contain critical breaking changes that have a major impact on data space participants, such as changes to enablement services.
 
@@ -37,9 +37,9 @@ Once feature work on product level is initiated, the quality assurance of the fo
 
 Reference onion rings: (add URL)
 
-Example for cxOS (https://catena-x.net/fileadmin/_online_media_/231006_Whitepaper_Tractus-X.pdf (https://catena-x.net/fileadmin/_online_media_/231006_Whitepaper_Tractus-X.pdf):
+Example for the Catena-X Operation System ("cxOS") [231006_Whitepaper_Tractus-X.pdf](https://catena-x.net/fileadmin/_online_media_/231006_Whitepaper_Tractus-X.pdf):
 
-A configured umbrella helm chart starts-up all relevant products. No matter if carry-over versions of a previous TX release or evolutions of the current iteration. User Journey tests (e2e) are automatically performed - customized for the respective bundle of products and within given boundary conditions.
+A configured umbrella helm chart starts-up all relevant products. No matter if carry-over product versions of a previous TX release or product evolutions, developed within the current iteration. User Journey tests (e2e) are automatically performed - customized for the respective bundle of products and within given boundary conditions.
 
 Any findings are looped back to the product development teams. Product teams are obliged to fix any defects which prevent successful testing of the bundle.
 
@@ -107,7 +107,7 @@ The stable channel is used by the release management group, to publish all helm 
 
 ## Versioning
 
-- Calendar versioning
+- [Calendar versioning](https://calver.org)
 
 
 ### Quality Assurance

--- a/docs/tractus-x-release.md
+++ b/docs/tractus-x-release.md
@@ -49,22 +49,25 @@ Additionally, manual e2e tests may apply. Environment and execution tbd.
 
 ### Operational steps to conclude the TX release
 
-Pre-requisites
-!!! If the last release, approved by the Eclipse Foundation, is more than a year old, you have to initiate a new release on the Eclipse Tractus-X Project page at least a week prior to the planned release date (see the Release steps)
-•	Helm chart versions and app versions for all products intended for the release
-•	An official announcement text highlighting release features, vital for the announcement email
-•	An optional official announcement image usable for the Eclipse Tractus-X Project page
+#### Pre-requisites
 
-1. Verify the presence of all helm chart versions in the release helm repository
-1. Verify all referenced links are working (documentation, kits, etc.)
-1. Create a Pull Request with the new changelog entry
-1.	Gather feedback and proceed with the merge
-1.	Create a GitHub release and incorporate the new changelog entry
-1.	Insert the new changelog entry under versions on the eclipse-tractusx changelog page
-1.	Register a new Tractus-X Release on the Eclipse Tractus-X Project page (Navigate to the Create new release button/link on the right side)
-1.	Modify the Download section on the Eclipse Tractus-X Project page via the Downloads, Software Repositories, and Marketplace -> Downloads Message section
-1. Compose an email to the tractusx-dev mailing list announcing the new release
-      Example:
+- __!!!__ If the last release, approved by the Eclipse Foundation, is more than a year old, you have to initiate a new release on the [Eclipse Tractus-X Project page](https://projects.eclipse.org/projects/automotive.tractusx) at least a week prior to the planned release date (see the [Release steps](#release-steps))
+- Helm chart versions and app versions for all products intended for the release
+- An official announcement text highlighting release features, vital for the announcement email
+- An optional official announcement image usable for the Eclipse Tractus-X Project page
+
+#### Release Steps
+
+- Verify the presence of all helm chart versions in the release helm repository
+- Verify all referenced links are working (documentation, kits, etc.)
+- Create a Pull Request with the new changelog entry
+- Gather feedback and proceed with the merge
+- Create a GitHub release and incorporate the new changelog entry
+- Insert the new changelog entry under versions on the [eclipse-tractusx changelog page](https://eclipse-tractusx.github.io/CHANGELOG/)
+- Register a new Tractus-X Release on the [Eclipse Tractus-X Project page](https://projects.eclipse.org/projects/automotive.tractusx) (Navigate to the Create new release button/link on the right side)
+- Modify the Download section on the [Eclipse Tractus-X Project page](https://projects.eclipse.org/projects/automotive.tractusx) via the Downloads, Software Repositories, and Marketplace -> Downloads Message section
+- Compose an email to the [tractusx-dev mailing list](mailto:tractusx-dev@eclipse.org) announcing the new release
+- Example:
 
 ```
 Subject line: [tractusx-dev] Announcing Tractus-X 24.03 - Latest Release Now Available 🎉

--- a/docs/tractus-x-release.md
+++ b/docs/tractus-x-release.md
@@ -35,13 +35,11 @@ Products **must** opt-in to the process in order to be included in a Tractus-X r
 
 Once feature work on product level is initiated, the quality assurance of the foreseen release package runs in parallel. The vehicle of Umbrella helm charts is used to continuously test pre-defined product bundles. Automatically and environment-less.
 
-Reference onion rings: (add URL)
-
 Example for the Catena-X Operation System ("cxOS") [231006_Whitepaper_Tractus-X.pdf](https://catena-x.net/fileadmin/_online_media_/231006_Whitepaper_Tractus-X.pdf):
 
-A configured umbrella helm chart starts-up all relevant products. No matter if carry-over product versions of a previous TX release or product evolutions, developed within the current iteration. User Journey tests (e2e) are automatically performed - customized for the respective bundle of products and within given boundary conditions.
+A configured umbrella helm chart starts-up all relevant products. No matter if carry-over versions of a previous Tractus-X release or evolutions of the current iteration. User Journey tests (e2e) are automatically performed - customized for the respective bundle of products and within given boundary conditions.
 
-Any findings are looped back to the product development teams. Product teams are obliged to fix any defects which prevent successful testing of the bundle.
+Any findings are looped back to the [product development teams](product_release.md). Product teams are obliged to fix any defects which prevent successful testing of the bundle.
 
 A bundle is ready for Tractus-X release, once product feature work is completed for all products and e2e-testing was successful without critical findings.
 Additionally, manual e2e tests may apply. Environment and execution tbd.

--- a/docs/tractus-x-release.md
+++ b/docs/tractus-x-release.md
@@ -1,3 +1,5 @@
+# Tractus-X Release
+
 ## Intro
 
 Tractus-X operates on a quarterly release cycle. Each quarter, a new Tractus-X release following [CalVer](https://calver.org) is released. Each Tractus-X release contains multiple [products](product_release.md).

--- a/docs/tractus-x-release.md
+++ b/docs/tractus-x-release.md
@@ -39,7 +39,7 @@ Once feature work on product level is initiated, the quality assurance of the fo
 
 Example for the Catena-X Operation System ("cxOS") [231006_Whitepaper_Tractus-X.pdf](https://catena-x.net/fileadmin/_online_media_/231006_Whitepaper_Tractus-X.pdf):
 
-A configured umbrella helm chart starts-up all relevant products. No matter if carry-over versions of a previous Tractus-X release or evolutions of the current iteration. User Journey tests (e2e) are automatically performed - customized for the respective bundle of products and within given boundary conditions.
+A configured umbrella helm chart starts-up all relevant products. **No matter if carry-over versions of a previous Tractus-X release or evolutions of the current iteration. User Journey tests (e2e) are automatically performed - customized for the respective bundle of products and within given boundary conditions.**
 
 Any findings are looped back to the [product development teams](product_release.md). Product teams are obliged to fix any defects which prevent successful testing of the bundle.
 


### PR DESCRIPTION
This PR combines the content of the website and tractus-x-release repository into sig-release.

It thereby fixes the [Issue #572](https://github.com/eclipse-tractusx/sig-release/issues/572)

See:
- https://github.com/eclipse-tractusx/tractus-x-release/pull/26
- https://github.com/eclipse-tractusx/eclipse-tractusx.github.io/pull/852

Superseeds https://github.com/eclipse-tractusx/sig-release/pull/519