### PR TITLE
docs: add OpenAPI spec section description to metadata file

### DIFF
--- a/docs/metadata_file.md
+++ b/docs/metadata_file.md
@@ -62,6 +62,16 @@ skipReleaseChecks:
     - "path/to/Dockerfile/only/used/in/testing-pipeline/Dockerfile.ui-tests"
 ```
 
+## OpenAPI Specification
+
+It is possible and highly recommended to list OpenAPI specifications related to your product in the respective section `openApiSpecs` of metadata file as in the example below:
+
+```yaml
+openApiSpecs:
+- "https://raw.githubusercontent.com/eclipse-tractus/<your-product-repo>/product_version_openapi.yaml"
+```
+
+Provided specifications are used by automation to generate and publish Swagger UI documentations.
 
 ## Full example
 
@@ -86,5 +96,7 @@ repositories:
 skipReleaseChecks:
   alignedBaseImage:
     - "/path/to/non-published/Dockerfile"
+openApiSpecs:
+- "https://raw.githubusercontent.com/eclipse-tractus/<your-product-repo>/product_version_openapi.yaml"
 
 ```


### PR DESCRIPTION
## Description

PR to update metadata file doc with description of new propriety to list product related OpenAPI specs for automation generating and publishing Swagger UI doc.


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
