### PR TITLE
chore: Adapt feature template concerning implementation commitment message

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_feature_template.md
+++ b/.github/ISSUE_TEMPLATE/1_feature_template.md
@@ -98,5 +98,4 @@ The following items are ensured (answer: yes) after this issue is implemented:
 
 ## Additional information
 <!-- this is only needed, if contributors and committers are not known during feature creation -->
-- [ ] I leave this unticked as it is natural for me that I only propose features for which I commit the proper investment to get them implemented. If I have to tick it, I understand that contributing a feature without the capacity to implement it is very bad style, but I humbly ask for support because I still think this is a great idea.
-- [ ] I provide necessary developer resources
+- [ ] I am aware that my request may not be developed if no developer can be found for it. I'll try to contribute a developer (bring your own developer)


### PR DESCRIPTION
## Description

Adapt the feature issue template. The message for the checkbox about commitment for implementation of the feature is adapted to be less pointed

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
