### PR TITLE
docs(issue template): add about information to KIT template

### DIFF
--- a/.github/ISSUE_TEMPLATE/5_KIT_template.md
+++ b/.github/ISSUE_TEMPLATE/5_KIT_template.md
@@ -1,5 +1,6 @@
 ---
 name: Propose KIT
+about: Propose a new KIT or adapt given one
 labels: kit
 ---
 


### PR DESCRIPTION
## Description

This PR adds the “about” information. Otherwise, the template is not shown

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
