### PR TITLE
chore(release-notifier): switch kubernetes version

### DIFF
--- a/.github/workflows/release-notifier.yaml
+++ b/.github/workflows/release-notifier.yaml
@@ -33,7 +33,7 @@ env:
     DEVSECOPS_NOTIFICATION_EMAIL: eclipse.tractusx@gmail.com
     DEVSECOPS_NOTIFICATION_EMAIL_PASSWORD: ${{ secrets.NOTIFICATION_EMAIL_PASSWORD }}
     CURRENT_ALIGNED_PSQL_VER: 15.0.0
-    CURRENT_ALIGNED_K8S_VER: 1.28.9
+    CURRENT_ALIGNED_K8S_VER: 1.33.1
 jobs:
   notify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

As already communicated an upgrade to kubernetes version 1.33.1 was needed -> release-notifier update.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
