### PR TITLE
Feat: add checks for TRG 1-05, TRG 1-06, TRG 7-07

### DIFF
--- a/dependencies_update.sh
+++ b/dependencies_update.sh
@@ -1,5 +1,24 @@
 #!/bin/bash
 #
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+#
 # Script used to generate concatenated dependencies from TRG dashboard & release notifier.
 # Ensure you have latest Eclipse Dash License tool:
 # https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=LATEST

--- a/docs/metadata_file.md
+++ b/docs/metadata_file.md
@@ -62,6 +62,33 @@ skipReleaseChecks:
     - "path/to/Dockerfile/only/used/in/testing-pipeline/Dockerfile.ui-tests"
 ```
 
+### Define Deviating Architecture Doc Folder for Built Documentation (TRG 1.05)
+
+[TRG 1.05](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-05/) foresees the architecture documentation in `docs/architecture`. If you use e.g. AsciiDoc you might want to specify a deviating directory as you commonly have `src` folder that needs to be compiled / built.
+
+```yaml
+# section to explicitly reconfigure certain release guideline checks
+configureReleaseChecks:
+  # Define a deviation from docs/architecture/ for your arc42
+  ArchitectureDocEntryPath: docs/src/architecture/
+```
+
+### Exclude Markdown / AsciiDoc Files from Notice Section Check (TRG 7.07)
+
+As defined in [TRG 7.07](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-07#how-to-include-legal-notices), all documents need to have a notice section at the end of the file specifying in heading 2 a notice file.
+
+By default, the `.github` directory is excluded from this check, but all other files are validated.
+
+```yaml
+# section to explicitly skip certain release guideline checks
+skipReleaseChecks:
+  # Skip the Notice section for non-distributed artefacts that don't need a notice section
+  LegalNoticeNonCode:
+    # exclude the directory src/assets
+    # this makes sense e.g. if you have a workflow that replaces a user_guide during release / distribution in the frontend that includes a notice section but you place a dummy file there.
+    - frontend/src/assets/
+```
+
 ## OpenAPI Specification
 
 It is possible and highly recommended to list OpenAPI specifications related to your product in the respective section `openApiSpecs` of metadata file as in the example below:

--- a/release-automation/README.md
+++ b/release-automation/README.md
@@ -28,7 +28,7 @@ $PROGRAM_PATH checkLocal ./
 
 ### Local Testing
 
-You need to define the GITHUB_ACCESS_TOKEN to create the dashboard as you'll else will run into a 403 RATE LIMIT. Having a the GitHub CLI installed, you can use the following command to set it:
+You need to define the GITHUB_ACCESS_TOKEN to create the dashboard, as you'll else will run into a 403 RATE LIMIT. Having the GitHub CLI installed, you can use the following command to set it:
 
 ```bash
 export GITHUB_ACCESS_TOKEN=$(gh auth token)

--- a/release-automation/README.md
+++ b/release-automation/README.md
@@ -8,6 +8,24 @@ are gathered to provided an overview on product basis.
 
 ## Development
 
+To run the go program locally, do as follows:
+
+```bash
+# build the program
+cd release-automation
+go build -o release-automation
+PROGRAM_PATH=$(pwd)/release-automation
+# executable is created in release-automation/release-automation
+# you can now run the program with $PROGRAM_PATH
+
+# Example: run trg checks locally
+cd <root-of-your-repo>
+$PROGRAM_PATH checkLocal ./
+```
+
+> [!Tip]
+> Please refer to the [cobra command files](./cmd) to learn more about to running the commands.
+
 ### Local Testing
 
 You need to define the GITHUB_ACCESS_TOKEN to create the dashboard as you'll else will run into a 403 RATE LIMIT. Having a the GitHub CLI installed, you can use the following command to set it:

--- a/release-automation/README.md
+++ b/release-automation/README.md
@@ -8,6 +8,14 @@ are gathered to provided an overview on product basis.
 
 ## Development
 
+### Local Testing
+
+You need to define the GITHUB_ACCESS_TOKEN to create the dashboard as you'll else will run into a 403 RATE LIMIT. Having a the GitHub CLI installed, you can use the following command to set it:
+
+```bash
+export GITHUB_ACCESS_TOKEN=$(gh auth token)
+```
+
 ### Styling
 
 We are using [Materialize](https://materializecss.com) as frontend framework to style this page.

--- a/release-automation/cmd/run_trg_checks.go
+++ b/release-automation/cmd/run_trg_checks.go
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -27,6 +28,7 @@ import (
 	"tractusx-release-automation/internal/container"
 	"tractusx-release-automation/internal/docs"
 	"tractusx-release-automation/internal/helm"
+	"tractusx-release-automation/internal/open_source"
 	"tractusx-release-automation/internal/repo"
 	"tractusx-release-automation/internal/test_runner"
 	"tractusx-release-automation/internal/tractusx"
@@ -46,10 +48,13 @@ var checkLocalCmd = &cobra.Command{
 			basedir = "./"
 		}
 
+		// TODO implement product-wise release guidelines
 		var releaseGuidelines = []tractusx.QualityGuideline{
 			docs.NewReadmeExists(basedir),
 			docs.NewInstallExists(basedir),
 			docs.NewChangelogExists(basedir),
+			docs.NewAdminGuideExists(basedir),
+			docs.NewArchitectureDocumentationExists(basedir),
 			repo.NewDefaultBranch(basedir),
 			repo.NewRepoStructureExists(basedir),
 			repo.NewLeadingRepositoryDefined(basedir),
@@ -58,6 +63,7 @@ var checkLocalCmd = &cobra.Command{
 			helm.NewHelmStructureExists(basedir),
 			helm.NewResourceMgmt(basedir),
 			helm.NewHelmWorkflowCheck(basedir),
+			open_source.NewNoticeForNonCodeExists(basedir),
 		}
 
 		runner := testrunner.NewTestRunner(releaseGuidelines)

--- a/release-automation/cmd/run_trg_checks.go
+++ b/release-automation/cmd/run_trg_checks.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
 	"tractusx-release-automation/internal/container"
 	"tractusx-release-automation/internal/docs"
 	"tractusx-release-automation/internal/helm"
@@ -32,6 +31,8 @@ import (
 	"tractusx-release-automation/internal/repo"
 	"tractusx-release-automation/internal/test_runner"
 	"tractusx-release-automation/internal/tractusx"
+
+	"github.com/spf13/cobra"
 )
 
 // checkLocalCmd represents the checkLocal command
@@ -48,7 +49,6 @@ var checkLocalCmd = &cobra.Command{
 			basedir = "./"
 		}
 
-		// TODO implement product-wise release guidelines
 		var releaseGuidelines = []tractusx.QualityGuideline{
 			docs.NewReadmeExists(basedir),
 			docs.NewInstallExists(basedir),

--- a/release-automation/internal/dashboard/tractusx.go
+++ b/release-automation/internal/dashboard/tractusx.go
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -157,6 +158,8 @@ func initializeChecksForDirectory(dir string) []tractusx.QualityGuideline {
 	checks = append(checks, docs.NewReadmeExists(dir))
 	checks = append(checks, docs.NewInstallExists(dir))
 	checks = append(checks, docs.NewChangelogExists(dir))
+	checks = append(checks, docs.NewAdminGuideExists(dir))
+	checks = append(checks, docs.NewArchitectureDocumentationExists(dir))
 	checks = append(checks, repo.NewDefaultBranch(dir))
 	checks = append(checks, repo.NewRepoStructureExists(dir))
 	checks = append(checks, repo.NewLeadingRepositoryDefined(dir))

--- a/release-automation/internal/docs/admin_guide_exists.go
+++ b/release-automation/internal/docs/admin_guide_exists.go
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package docs
+
+import (
+	"path"
+	"path/filepath"
+	"tractusx-release-automation/internal/tractusx"
+)
+
+type AdminGuideExists struct {
+	baseDir string
+}
+
+func NewAdminGuideExists(baseDir string) tractusx.QualityGuideline {
+	return &AdminGuideExists{baseDir: baseDir}
+}
+
+func (a *AdminGuideExists) Name() string { return "TRG 1.06 - docs/admin" }
+
+func (a *AdminGuideExists) Description() string {
+	return "Tractus-X components and applications may be operated in various productive environments. An Administrator`s guide shall help operators to install and operate the solution. It can also be a vehicle to share best-practices on maintenance etc."
+}
+
+func (a *AdminGuideExists) ExternalDescription() string {
+	return "https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-06"
+}
+
+func (a *AdminGuideExists) BaseDir() string {
+	return a.baseDir
+}
+
+func (a *AdminGuideExists) Test() *tractusx.QualityResult {
+	matches, err := filepath.Glob(path.Join(a.baseDir, "docs", "admin", "*.md"))
+
+	if err != nil || len(matches) == 0 {
+		return &tractusx.QualityResult{ErrorDescription: "A markdown file providing the admin guide has to be present."}
+	}
+	return &tractusx.QualityResult{Passed: true}
+}
+
+func (a *AdminGuideExists) IsOptional() bool {
+	return true
+}

--- a/release-automation/internal/docs/admin_guide_exists_test.go
+++ b/release-automation/internal/docs/admin_guide_exists_test.go
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package docs
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+)
+
+// TODO: outsource the function as a supporting function for tests
+func TestPassIfAnyMarkdownFileIsPresent(t *testing.T) {
+	dir := t.TempDir()
+	filePath := path.Join(dir, "docs", "admin", "README.md")
+
+	err := os.MkdirAll(path.Dir(filePath), os.ModePerm)
+	if err != nil {
+		t.Fatalf("failed to create directories: %v", err)
+	}
+
+	fmt.Printf("%s\n", filePath)
+	_, err = os.Create(filePath)
+	if err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	fmt.Printf("%s\n", filePath)
+	_, _ = os.Create(filePath)
+
+	result := NewAdminGuideExists(dir).Test()
+
+	if !result.Passed {
+		t.Error("Admin Guide is not in directory")
+	}
+}
+
+func TestFailIfMarkdownFileIsMissing(t *testing.T) {
+	dir := t.TempDir()
+	filePath := path.Join(dir, "docs", "admin", "README.txt")
+	err := os.MkdirAll(path.Dir(filePath), os.ModePerm)
+	if err != nil {
+		t.Fatalf("failed to create directories: %v", err)
+	}
+
+	fmt.Printf("%s\n", filePath)
+	_, err = os.Create(filePath)
+	if err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	fmt.Printf("%s\n", filePath)
+	_, _ = os.Create(filePath)
+
+	result := NewAdminGuideExists(dir).Test()
+
+	if result.Passed {
+		t.Error("AdminGuideExists should fail if no Markdown is present in docs/admin.")
+	}
+}
+
+// TODO why does go show an error, if I name this differently?
+func TestProvidesErrorDescriptionIfFailing(t *testing.T) {
+	result := NewChangelogExists("./").Test()
+
+	if result.ErrorDescription == "" {
+		t.Errorf("Failing tests should provide an error description")
+	}
+}

--- a/release-automation/internal/docs/admin_guide_exists_test.go
+++ b/release-automation/internal/docs/admin_guide_exists_test.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 )
 
-// TODO: outsource the function as a supporting function for tests
 func TestPassIfAnyMarkdownFileIsPresent(t *testing.T) {
 	dir := t.TempDir()
 	filePath := path.Join(dir, "docs", "admin", "README.md")
@@ -77,7 +76,6 @@ func TestFailIfMarkdownFileIsMissing(t *testing.T) {
 	}
 }
 
-// TODO why does go show an error, if I name this differently?
 func TestProvidesErrorDescriptionIfFailing(t *testing.T) {
 	result := NewChangelogExists("./").Test()
 

--- a/release-automation/internal/docs/architecture_documentation_exists.go
+++ b/release-automation/internal/docs/architecture_documentation_exists.go
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package docs
+
+import (
+	"log"
+	"path"
+	"path/filepath"
+	"tractusx-release-automation/internal/tractusx"
+)
+
+var allowedArchitectureDocsGlob = []string{
+	"docs/architecture/*.md",
+	"docs/architecture/*.adoc",
+}
+
+type ArchitectureDocumentationExists struct {
+	baseDir string
+}
+
+func NewArchitectureDocumentationExists(baseDir string) tractusx.QualityGuideline {
+	return &ArchitectureDocumentationExists{baseDir}
+}
+
+func (r *ArchitectureDocumentationExists) IsOptional() bool {
+	return false
+}
+
+func (r *ArchitectureDocumentationExists) Name() string {
+	return "TRG 1.05 - Arc42 Documentation"
+}
+
+func (r *ArchitectureDocumentationExists) Description() string {
+	return "Proper Architecture Documentation is necessary to support architects and operation teams for their decisions making processes and operative tasks. It therefore provides information like context, integration interfaces and intended usage of the component. We follow the good practice to document the Architecture of components."
+}
+
+func (r *ArchitectureDocumentationExists) ExternalDescription() string {
+	return "https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-05"
+}
+
+func (r *ArchitectureDocumentationExists) BaseDir() string {
+	return r.baseDir
+}
+
+func (r *ArchitectureDocumentationExists) Test() *tractusx.QualityResult {
+	checkPassed := false
+	filepath.Glob(path.Join(r.baseDir, "*.md"))
+
+	allowedGlobs := getArchitectureDocEntryPaths(r.baseDir)
+
+	for _, allowedGlob := range allowedGlobs {
+		matches, err := filepath.Glob(path.Join(r.baseDir, allowedGlob))
+		if err != nil || len(matches) > 0 {
+			log.Printf("Did FIND a file matching glob %s", allowedGlob)
+			checkPassed = true
+		} else {
+			log.Printf("Did NOT find a file matching glob %s", allowedGlob)
+		}
+	}
+
+	if checkPassed == false {
+		return &tractusx.QualityResult{ErrorDescription: "Did not find a markdown or adoc file in folder docs/architecture OR specified path (.tractusx file)!"}
+	}
+	return &tractusx.QualityResult{Passed: true}
+}
+
+// return allowedArchitectureDocsGlob + ArchitectureDocEntryPath from .tractusx
+func getArchitectureDocEntryPaths(dir string) []string {
+	file, err := tractusx.MetadataFromLocalFile(dir)
+
+	if err != nil {
+		return allowedArchitectureDocsGlob
+	}
+
+	return append(allowedArchitectureDocsGlob, file.ArchitectureDocEntryPath)
+}

--- a/release-automation/internal/docs/architecture_documentation_exists_test.go
+++ b/release-automation/internal/docs/architecture_documentation_exists_test.go
@@ -1,0 +1,181 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+package docs
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	"tractusx-release-automation/internal/tractusx"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestShouldFailIfArchitectureDocumentationDoesNotExist(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := path.Join(tmpDir, "docs", "architecture", "WrongFile.yaml")
+
+	err := os.MkdirAll(path.Dir(filePath), os.ModePerm)
+	if err != nil {
+		t.Fatalf("failed to create directories: %v", err)
+	}
+
+	_, err = os.Create(filePath)
+	if err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+	fmt.Printf("%s\n", filePath)
+
+	result := NewArchitectureDocumentationExists(tmpDir).Test()
+
+	if result.Passed {
+		t.Errorf("Architecture documentation check should fail, if no architecture documentation is present")
+	}
+}
+
+func TestShouldPassIfArchitectureDocumentationFromTractusxFileExists(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := path.Join(tmpDir, "docs", "architecture", "arc42", "markdown.md")
+
+	err := os.MkdirAll(path.Dir(filePath), os.ModePerm)
+	if err != nil {
+		t.Fatalf("failed to create directories: %v", err)
+	}
+
+	_, err = os.Create(filePath)
+	if err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	saveMetadataConfigToSkip(path.Join("docs", "architecture", "arc42", "markdown.md"), tmpDir)
+	fmt.Printf("%s\n", filePath)
+
+	result := NewArchitectureDocumentationExists(tmpDir).Test()
+
+	if !result.Passed {
+		t.Errorf("Architecture documentation check should pass, because the file has been specified via .tractusx.")
+	}
+}
+
+func TestShouldFailIfArchitectureDocumentationFromTractusxFileDoesNotExist(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := path.Join(tmpDir, "docs", "architecture", "arc42", "WRONG.md")
+
+	err := os.MkdirAll(path.Dir(filePath), os.ModePerm)
+	if err != nil {
+		t.Fatalf("failed to create directories: %v", err)
+	}
+
+	_, err = os.Create(filePath)
+	if err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	saveMetadataConfigToSkip(path.Join("docs", "architecture", "arc42", "markdown.md"), tmpDir)
+	fmt.Printf("%s\n", filePath)
+
+	result := NewArchitectureDocumentationExists(tmpDir).Test()
+
+	if result.Passed {
+		t.Errorf("Architecture documentation check should fail, if no architecture documentation is present in .tractux file location")
+	}
+}
+
+//func TestProvideErrorDescriptionOnFailingTest(t *testing.T) {
+//	expectedError := "Did not find a README.md file in current directory!"
+//
+//	result := NewReadmeExists("./").Test()
+//
+//	if result.ErrorDescription != expectedError {
+//		t.Errorf("Readme check does not provide correct error description on failing check! \nexprected: %s, \ngot: %s", expectedError, result.ErrorDescription)
+//	}
+//}
+
+func TestShouldPassIfArchitectureDocumentationMdExists(t *testing.T) {
+
+	tmpDir := t.TempDir()
+	filePath := path.Join(tmpDir, "docs", "architecture", "README.md")
+
+	err := os.MkdirAll(path.Dir(filePath), os.ModePerm)
+	if err != nil {
+		t.Fatalf("failed to create directories: %v", err)
+	}
+
+	_, err = os.Create(filePath)
+	if err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	result := NewArchitectureDocumentationExists(tmpDir).Test()
+
+	if !result.Passed {
+		t.Errorf("Architecture documentation exists, but test still fails")
+	}
+
+}
+
+func TestShouldPassIfArchitectureDocumentationAdocExists(t *testing.T) {
+
+	tmpDir := t.TempDir()
+	filePath := path.Join(tmpDir, "docs", "architecture", "README.adoc")
+
+	err := os.MkdirAll(path.Dir(filePath), os.ModePerm)
+	if err != nil {
+		t.Fatalf("failed to create directories: %v", err)
+	}
+
+	_, err = os.Create(filePath)
+	if err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	result := NewArchitectureDocumentationExists(tmpDir).Test()
+
+	if !result.Passed {
+		t.Errorf("Architecture documentation exists, but test still fails")
+	}
+
+}
+
+//func TestShouldFindReadmeAtGivenBasePath(t *testing.T) {
+//	dir := t.TempDir()
+//	if _, err := os.Create(path.Join(dir, "README.md")); err != nil {
+//		t.Errorf("Could not create README.md for test")
+//	}
+//
+//	result := NewReadmeExists(dir).Test()
+//
+//	if !result.Passed {
+//		t.Errorf("Could not find README.md at given base path")
+//	}
+//}
+
+func saveMetadataConfigToSkip(architectureDocPath string, dir string) {
+	metadata := tractusx.Metadata{
+		ConfigureReleaseChecks: tractusx.ConfigureReleaseChecks{
+			ArchitectureDocEntryPath: architectureDocPath,
+		},
+	}
+
+	bytes, _ := yaml.Marshal(&metadata)
+	_ = os.WriteFile(path.Join(dir, ".tractusx"), bytes, 0644)
+}

--- a/release-automation/internal/docs/architecture_documentation_exists_test.go
+++ b/release-automation/internal/docs/architecture_documentation_exists_test.go
@@ -100,16 +100,6 @@ func TestShouldFailIfArchitectureDocumentationFromTractusxFileDoesNotExist(t *te
 	}
 }
 
-//func TestProvideErrorDescriptionOnFailingTest(t *testing.T) {
-//	expectedError := "Did not find a README.md file in current directory!"
-//
-//	result := NewReadmeExists("./").Test()
-//
-//	if result.ErrorDescription != expectedError {
-//		t.Errorf("Readme check does not provide correct error description on failing check! \nexprected: %s, \ngot: %s", expectedError, result.ErrorDescription)
-//	}
-//}
-
 func TestShouldPassIfArchitectureDocumentationMdExists(t *testing.T) {
 
 	tmpDir := t.TempDir()
@@ -155,19 +145,6 @@ func TestShouldPassIfArchitectureDocumentationAdocExists(t *testing.T) {
 	}
 
 }
-
-//func TestShouldFindReadmeAtGivenBasePath(t *testing.T) {
-//	dir := t.TempDir()
-//	if _, err := os.Create(path.Join(dir, "README.md")); err != nil {
-//		t.Errorf("Could not create README.md for test")
-//	}
-//
-//	result := NewReadmeExists(dir).Test()
-//
-//	if !result.Passed {
-//		t.Errorf("Could not find README.md at given base path")
-//	}
-//}
 
 func saveMetadataConfigToSkip(architectureDocPath string, dir string) {
 	metadata := tractusx.Metadata{

--- a/release-automation/internal/open_source/legal_notice_non_code_exists.go
+++ b/release-automation/internal/open_source/legal_notice_non_code_exists.go
@@ -1,0 +1,250 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package open_source
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"tractusx-release-automation/internal/tractusx"
+)
+
+var consideredFileRegexes = []string{
+	".md",
+	".adoc",
+}
+
+var excludedFileGlobs = []string{
+	".github/",
+	"CHANGELOG.md",
+	"CODE_OF_CONDUCT.md",
+	"CONTRIBUTING.md",
+	"INSTALL.md",
+	"SECURITY.md",
+	"NOTICE.md",
+	"**/NOTICE.md",
+	"**/DOCKER_NOTICE.md",
+}
+
+type NoticeForNonCodeExists struct {
+	baseDir string
+}
+
+func NewNoticeForNonCodeExists(baseDir string) tractusx.QualityGuideline {
+	return &NoticeForNonCodeExists{baseDir}
+}
+
+func (r *NoticeForNonCodeExists) IsOptional() bool {
+	return false
+}
+
+func (r *NoticeForNonCodeExists) Name() string {
+	return "TRG 7.07 - Notice Section For Non-Code (Documentation)"
+}
+
+func (r *NoticeForNonCodeExists) Description() string {
+	return "For text files, like files in the markdown format, the attribution is done directly in the file as described in this section. The attribution is shown with an example for a CC-BY-4.0 licensed markdown file. For other formats like slides, pdf, and others adapt the information in an adequate way."
+}
+
+func (r *NoticeForNonCodeExists) ExternalDescription() string {
+	return "https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-07#documentation"
+}
+
+func (r *NoticeForNonCodeExists) BaseDir() string {
+	return r.baseDir
+}
+
+func (r *NoticeForNonCodeExists) Test() *tractusx.QualityResult {
+	checkPassed := true
+
+	excludedGlobs := getExcludedGlobs(r.baseDir)
+	log.Printf("Going to exclude the following files for notice section check: %v", excludedGlobs)
+
+	files, err := collectDocumentationFiles(r.baseDir, excludedGlobs)
+
+	if err != nil {
+		log.Printf("Could not collect documentation files due ot error: %s", err)
+		return &tractusx.QualityResult{ErrorDescription: "Unable to find all markdown or adoc files!"}
+	}
+
+	invalidFiles := []string{}
+	for _, file := range files {
+		_, err := checkNoticeSection(file)
+
+		if err != nil {
+			checkPassed = false
+			invalidFiles = append(invalidFiles, file)
+			log.Printf("Could not find notice section with heading 2, SPDX-License-Identifier, SPDX-File-CopyrightText, Source URK for file: %s", file)
+		}
+	}
+
+	if checkPassed == false {
+		return &tractusx.QualityResult{ErrorDescription: fmt.Sprintf("Could not find notice section with heading 2, SPDX-License-Identifier, SPDX-File-CopyrightText, Source URK for following files: %v", invalidFiles)}
+	}
+	return &tractusx.QualityResult{Passed: true}
+}
+
+// Performs the following checks:
+// - file ends with heading 2 "Notice" (.adoc == NOTICE)
+// - license is contained (- SPDX-License-Identifier: CC-BY-4.0)
+// - at least one copyright holder (- SPDX-FileCopyrightText: YYYY Name)
+// - url is contained (- Source URL)
+func checkNoticeSection(filePath string) (bool, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return false, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+
+	var lastHeading string
+	var hasSPDX bool
+	var hasCopyright bool
+	var hasSourceURL bool
+
+	// Regular expressions for matching SPDX and Source URL
+	spdxRegex := regexp.MustCompile(`^- SPDX-License-Identifier: .+`)
+	copyrightRegex := regexp.MustCompile(`^- SPDX-FileCopyrightText: \d{4} .+`)
+	sourceURLRegex := regexp.MustCompile(`^- Source URL: .+`)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		// Check for last heading based on file type
+		if strings.HasSuffix(filePath, ".md") && strings.HasPrefix(line, "## ") {
+			lastHeading = line[3:] // Get the heading text
+		} else if strings.HasSuffix(filePath, ".adoc") && strings.HasPrefix(line, "== ") {
+			lastHeading = line[3:] // Get the heading text
+		}
+
+		// Check for SPDX License Identifier
+		if spdxRegex.MatchString(line) {
+			hasSPDX = true
+		}
+
+		// Check for Copyright Holder
+		if copyrightRegex.MatchString(line) {
+			hasCopyright = true
+		}
+
+		// Check for Source URL
+		if sourceURLRegex.MatchString(line) {
+			hasSourceURL = true
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return false, err
+	}
+
+	// Validate the conditions
+	isValid := false
+
+	//log.Printf("File %s has lastHeading '%s'.", filePath, lastHeading)
+	// we could use strings.ToUpper(lastHeading) if we would like to not explictly check the UPPERCASENES
+	if lastHeading == "NOTICE" {
+		isValid = hasSPDX && hasCopyright && hasSourceURL
+	} else {
+		log.Printf("File %s misses Level 2 NOTICE (uppercase) header.", filePath)
+	}
+	if !hasSPDX {
+		log.Printf("File %s misses SPDX-License-Identifier.", filePath)
+	}
+	if !hasCopyright {
+		log.Printf("File %s misses SPDX-FileCopyrightText.", filePath)
+	}
+	if !hasSourceURL {
+		log.Printf("File %s misses Source URL .", filePath)
+	}
+
+	return isValid, nil
+}
+
+// Function to collect markdown and asciidoc files considering exlusions
+func collectDocumentationFiles(baseDir string, excludedGlobs []string) ([]string, error) {
+	var collectedFiles []string
+
+	err := filepath.Walk(baseDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Check if the file has the desired extensions
+		if !info.IsDir() && (strings.HasSuffix(info.Name(), ".md") || strings.HasSuffix(info.Name(), ".adoc")) {
+			// Check against excluded globs
+			relativePath, err := filepath.Rel(baseDir, path)
+			if err != nil {
+				return err
+			}
+
+			if !matchesExcludedGlob(relativePath, excludedGlobs) {
+				collectedFiles = append(collectedFiles, path)
+			} else {
+
+			}
+		} else if info.IsDir() {
+			relativePath, err := filepath.Rel(baseDir, path)
+			if err != nil {
+				return err
+			}
+			for _, glob := range excludedGlobs {
+				if strings.HasPrefix(relativePath, strings.TrimSuffix(glob, "/")) {
+					return filepath.SkipDir
+				}
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return collectedFiles, nil
+}
+
+// Function to check if a file path matches any of the excluded globs
+func matchesExcludedGlob(path string, excludedGlobs []string) bool {
+
+	for _, glob := range excludedGlobs {
+
+		match, err := filepath.Match(glob, path)
+		if err == nil && match {
+			return true
+		}
+	}
+	return false
+}
+
+func getExcludedGlobs(dir string) []string {
+	file, err := tractusx.MetadataFromLocalFile(dir)
+
+	if err != nil {
+		return []string{}
+	}
+
+	return append(excludedFileGlobs, file.LegalNoticesNonCode...)
+}

--- a/release-automation/internal/open_source/legal_notice_non_code_exists.go
+++ b/release-automation/internal/open_source/legal_notice_non_code_exists.go
@@ -161,7 +161,7 @@ func checkNoticeSection(filePath string) (bool, error) {
 	isValid := false
 
 	//log.Printf("File %s has lastHeading '%s'.", filePath, lastHeading)
-	// we could use strings.ToUpper(lastHeading) if we would like to not explictly check the UPPERCASENES
+	// we could use strings.ToUpper(lastHeading) if we would like to not explicitly check the UPPERCASENES
 	if lastHeading == "NOTICE" {
 		isValid = hasSPDX && hasCopyright && hasSourceURL
 	} else {

--- a/release-automation/internal/open_source/legal_notice_non_code_exists.go
+++ b/release-automation/internal/open_source/legal_notice_non_code_exists.go
@@ -38,10 +38,7 @@ var consideredFileRegexes = []string{
 
 var excludedFileGlobs = []string{
 	".github/",
-	"CHANGELOG.md",
 	"CODE_OF_CONDUCT.md",
-	"CONTRIBUTING.md",
-	"INSTALL.md",
 	"SECURITY.md",
 	"NOTICE.md",
 	"**/NOTICE.md",

--- a/release-automation/internal/open_source/legal_notice_non_code_exists_test.go
+++ b/release-automation/internal/open_source/legal_notice_non_code_exists_test.go
@@ -98,7 +98,6 @@ func TestShouldPassIfInvalidFilesAreExcluded(t *testing.T) {
 
 	exclusionSlice := []string{
 		"subdir/missing_copyright_and_excluded.md",
-		//".github/*",
 	}
 
 	saveMetadataConfigToExclude(exclusionSlice, dir)

--- a/release-automation/internal/open_source/legal_notice_non_code_exists_test.go
+++ b/release-automation/internal/open_source/legal_notice_non_code_exists_test.go
@@ -1,0 +1,253 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package open_source
+
+import (
+	"log"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
+	"tractusx-release-automation/internal/tractusx"
+
+	"gopkg.in/yaml.v3"
+)
+
+type TestStruct struct {
+	content      string
+	dirPath      string
+	fileName     string
+	expected     bool
+	expectingErr bool
+}
+
+func TestShouldPassIfInvalidFilesAreExcluded(t *testing.T) {
+	tests := []TestStruct{
+		{
+			content: `## NOTICE
+- SPDX-License-Identifier: CC-BY-4.0
+- SPDX-FileCopyrightText: 2023 John Doe
+- Source URL: https://example.com`,
+			dirPath:  "./",
+			fileName: "valid.md",
+			expected: true,
+		},
+		{
+			content: `## notice
+- SPDX-License-Identifier: CC-BY-4.0
+- SPDX-FileCopyrightText: 2023 John Doe
+- Source URL: https://example.com`,
+			dirPath:  "subdir",
+			fileName: "invalid_notice.adoc",
+			expected: true,
+		},
+		{
+			content: `## NOTICE
+- SPDX-License-Identifier: CC-BY-4.0
+- Source URL: https://example.com`,
+			dirPath:  "subdir",
+			fileName: "missing_copyright_and_excluded.md",
+			expected: false,
+		},
+		{
+			content: `## NOTICE
+- SPDX-FileCopyrightText: 2023 John Doe
+- Source URL: https://example.com`,
+			dirPath:  "subdir",
+			fileName: "wrong_filetype.yaml",
+			expected: false,
+		},
+		{
+			content: `## NOTICE
+- SPDX-FileCopyrightText: 2023 John Doe
+- Source URL: https://example.com`,
+			dirPath:  ".github",
+			fileName: "excluded.md",
+			expected: false,
+		},
+		{
+			content: `## NOTICE
+- SPDX-FileCopyrightText: 2023 John Doe
+- Source URL: https://example.com`,
+			dirPath:  ".github/ISSUE_TEMPLATE",
+			fileName: "excluded.md",
+			expected: false,
+		},
+	}
+
+	dir := t.TempDir()
+
+	exclusionSlice := []string{
+		"subdir/missing_copyright_and_excluded.md",
+		//".github/*",
+	}
+
+	saveMetadataConfigToExclude(exclusionSlice, dir)
+
+	for _, test := range tests {
+
+		filePath := path.Join(dir, test.dirPath, test.fileName)
+
+		err := os.MkdirAll(path.Dir(filePath), os.ModePerm)
+		// Create a temporary file
+		tmpFile, err := os.Create(filePath)
+		if err != nil {
+			t.Fatalf("Could not create temp file: %v", err)
+		} else {
+			log.Printf("Created file %s.", filePath)
+		}
+		defer os.Remove(tmpFile.Name()) // Clean up
+
+		// Write test content to the file
+		if _, err := tmpFile.WriteString(test.content); err != nil {
+			t.Fatalf("Could not write to temp file: %v", err)
+		}
+		tmpFile.Close()
+	}
+
+	files, err := collectDocumentationFiles(dir, getExcludedGlobs(dir))
+
+	if err != nil {
+		t.Errorf("Unexpected error during collection of files: %v", err)
+	}
+
+	if len(files) != 2 {
+		t.Errorf("Two files should have been collected, but collected: %d", len(files))
+	}
+
+	matchingTests := []*TestStruct{}
+
+	for _, file := range files {
+		matchingTestCase := getMatchingTest(file, tests)
+		matchingTests = append(matchingTests, matchingTestCase)
+
+		if matchingTestCase == nil {
+			t.Errorf("Unexpected error as a test should be found for %s", file)
+		} else {
+			if matchingTestCase.expected == false {
+				t.Errorf("File %s for test case %v should have not been collected.", file, matchingTestCase)
+			} else {
+				log.Printf("File %s for test case %v has been collected successfully.", file, matchingTestCase)
+			}
+		}
+	}
+}
+
+func getMatchingTest(fileName string, tests []TestStruct) *TestStruct {
+	for _, testCase := range tests {
+		_, err := filepath.Match(fileName, path.Join(testCase.dirPath, testCase.fileName))
+		if err == nil {
+			return &testCase
+		}
+	}
+	return nil
+}
+
+func saveMetadataConfigToExclude(LegalNoticesNonCode []string, dir string) {
+	metadata := tractusx.Metadata{
+		SkipReleaseChecks: tractusx.SkipReleaseChecks{
+			LegalNoticesNonCode: LegalNoticesNonCode,
+		},
+	}
+
+	bytes, _ := yaml.Marshal(&metadata)
+	_ = os.WriteFile(path.Join(dir, ".tractusx"), bytes, 0644)
+}
+
+func TestCheckNoticeSection(t *testing.T) {
+	tests := []struct {
+		content      string
+		fileName     string
+		expected     bool
+		expectingErr bool
+	}{
+		{
+			content: `## NOTICE
+- SPDX-License-Identifier: CC-BY-4.0
+- SPDX-FileCopyrightText: 2023 John Doe
+- Source URL: https://example.com`,
+			fileName:     "valid.md",
+			expected:     true,
+			expectingErr: false,
+		},
+		{
+			content: `## notice
+- SPDX-License-Identifier: CC-BY-4.0
+- SPDX-FileCopyrightText: 2023 John Doe
+- Source URL: https://example.com`,
+			fileName:     "invalid_notice.md",
+			expected:     false,
+			expectingErr: false,
+		},
+		{
+			content: `## NOTICE
+- SPDX-License-Identifier: CC-BY-4.0
+- Source URL: https://example.com`,
+			fileName:     "missing_copyright.md",
+			expected:     false,
+			expectingErr: false,
+		},
+		{
+			content: `## NOTICE
+- SPDX-FileCopyrightText: 2023 John Doe
+- Source URL: https://example.com`,
+			fileName:     "missing_license.md",
+			expected:     false,
+			expectingErr: false,
+		},
+		{
+			content: `== NOTICE
+- SPDX-License-Identifier: CC-BY-4.0
+- SPDX-FileCopyrightText: 2023 John Doe
+- Source URL: https://example.com`,
+			fileName:     "valid.adoc",
+			expected:     true,
+			expectingErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		// Create a temporary file
+		tmpFile, err := os.Create(test.fileName)
+		if err != nil {
+			t.Fatalf("Could not create temp file: %v", err)
+		}
+		defer os.Remove(tmpFile.Name()) // Clean up
+
+		// Write test content to the file
+		if _, err := tmpFile.WriteString(test.content); err != nil {
+			t.Fatalf("Could not write to temp file: %v", err)
+		}
+		tmpFile.Close()
+
+		// Check file requirements
+		isValid, err := checkNoticeSection(tmpFile.Name())
+
+		if (err != nil) != test.expectingErr {
+			t.Errorf("Unexpected error for %s: %v", test.fileName, err)
+		}
+
+		if isValid != test.expected {
+			t.Errorf("Expected %v for %s, got %v", test.expected, test.fileName, isValid)
+		}
+	}
+}

--- a/release-automation/internal/tractusx/metadata.go
+++ b/release-automation/internal/tractusx/metadata.go
@@ -46,7 +46,8 @@ type Repository struct {
 }
 
 type SkipReleaseChecks struct {
-	AlignedBaseImages []string `yaml:"alignedBaseImage"`
+	AlignedBaseImages   []string `yaml:"alignedBaseImage"`
+	LegalNoticesNonCode []string `yaml:"legalNoticesNonCode"`
 }
 
 type ConfigureReleaseChecks struct {

--- a/release-automation/internal/tractusx/metadata.go
+++ b/release-automation/internal/tractusx/metadata.go
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -30,11 +31,12 @@ import (
 const MetadataFilename = ".tractusx"
 
 type Metadata struct {
-	ProductName       string       `yaml:"product"`
-	LeadingRepository string       `yaml:"leadingRepository"`
-	RepoCategory      string       `yaml:"repoCategory"`
-	Repositories      []Repository `yaml:"repositories"`
-	SkipReleaseChecks `yaml:"skipReleaseChecks"`
+	ProductName            string       `yaml:"product"`
+	LeadingRepository      string       `yaml:"leadingRepository"`
+	RepoCategory           string       `yaml:"repoCategory"`
+	Repositories           []Repository `yaml:"repositories"`
+	SkipReleaseChecks      `yaml:"skipReleaseChecks"`
+	ConfigureReleaseChecks `yaml:"configureReleaseChecks"`
 }
 
 type Repository struct {
@@ -45,6 +47,10 @@ type Repository struct {
 
 type SkipReleaseChecks struct {
 	AlignedBaseImages []string `yaml:"alignedBaseImage"`
+}
+
+type ConfigureReleaseChecks struct {
+	ArchitectureDocEntryPath string `yaml:"architectureDocEntryPath"`
 }
 
 // MetadataFromFile does take fileContent as byte slice and tries to deserialize it into Metadata.


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
I added further automatic checks for the release guidelines. Right now they are only applicable to the product repositories, but we could extend it to the eclipse-tractusx.github.io

- [TRG 1.05 ](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-05/) - Architecture Documentation
- [TRG 1.06](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-06) - Admin Guide
- [TRG 7.07](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-08) - Notice section for non-code documents

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
