### PR TITLE
chore(migrate-action-version): migrate checkout version

### DIFF
--- a/.github/workflows/verify-binary-build.yaml
+++ b/.github/workflows/verify-binary-build.yaml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: setup Go
         uses: actions/setup-go@v6


### PR DESCRIPTION
## Description

This PR "migrates" the used version (without any upgrade) for checkout action to SHA. NO upgrade is done.
The SHA values can be found [here](https://github.com/actions/checkout/releases)

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files